### PR TITLE
fixed includeTraceParent resolving

### DIFF
--- a/src/instrumentation/fetch.ts
+++ b/src/instrumentation/fetch.ts
@@ -174,7 +174,11 @@ export function instrumentFetcher(
 			const host = new URL(request.url).host
 			const spanName = typeof attrs?.['name'] === 'string' ? attrs?.['name'] : `fetch: ${host}`
 			const promise = tracer.startActiveSpan(spanName, options, async (span) => {
-				if (config.includeTraceContext) {
+				const includeTraceContext =
+					typeof config.includeTraceContext === 'function'
+						? config.includeTraceContext(request)
+						: config.includeTraceContext
+				if (includeTraceContext ?? true) {
 					propagation.inject(api_context.active(), request.headers, {
 						set: (h, k, v) => h.set(k, typeof v === 'string' ? v : String(v)),
 					})

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -107,7 +107,7 @@ function parseConfig(supplied: TraceConfig): ResolvedTraceConfig {
 	return {
 		exporter: isSpanExporter(supplied.exporter) ? supplied.exporter : new OTLPExporter(supplied.exporter),
 		fetch: {
-			includeTraceContext: supplied.fetch?.includeTraceContext || true,
+			includeTraceContext: supplied.fetch?.includeTraceContext ?? true,
 		},
 		postProcessor: supplied.postProcessor || ((spans: ReadableSpan[]) => spans),
 		sampling: {


### PR DESCRIPTION
### Description
This PR resolves #23 by updating the default value handling of `fetch.includeTraceContext`.

The value is now coalesced using `??` rather than `||` to preserve falsy values specified in the config. The fetch instrumentation proxy is also updated to detect the function variant and invoke it with the current outbound request.

### Testing
I've tested the variations manually by modifying the Workers example with the various options.