### PR TITLE
adding faas.execution attribute from cf-ray

### DIFF
--- a/src/instrumentation/fetch.ts
+++ b/src/instrumentation/fetch.ts
@@ -105,6 +105,7 @@ export function executeFetchHandler(fetchFn: FetchHandler, [request, env, ctx]: 
 	const attributes = {
 		[SemanticAttributes.FAAS_TRIGGER]: 'http',
 		[SemanticAttributes.FAAS_COLDSTART]: cold_start,
+		[SemanticAttributes.FAAS_EXECUTION]: request.headers.get('cf-ray') ?? undefined,
 	}
 	cold_start = false
 	Object.assign(attributes, gatherRequestAttributes(request))


### PR DESCRIPTION
This PR resolves #25 by assigning the `faas.execution` attribute to the [CF-Ray header](https://developers.cloudflare.com/fundamentals/get-started/reference/http-request-headers/#cf-ray) in the fetch handler instrumentation for inbound HTTP requests.

Note that the header is not set by `wrangler dev`, so this will only take effect on deployed Workers and Durable Objects.