### PR TITLE
adding acceptTraceContext option for fetch handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,24 @@ const exporter = {
 ### Fetch
 
 `includeTraceContext` is used to specify if outgoing requests should include the TraceContext so that the other service can participate in a distributed trace.
-The default is `true` for all outgoing requests, but you can turn it off for all requests with `false`,or specify a method that takes the outgoing `Request` method and return a boolean on whether to include the tracing context.
+The default is `true` for all outgoing requests, but you can turn it off for all requests with `false`, or specify a method that takes the outgoing `Request` method and return a boolean on whether to include the tracing context.
+
+Example:
+
+```typescript
+const fetchConf = (request: Request): boolean => {
+	return new URL(request.url).hostname === 'example.com'
+}
+```
+
+### Handlers
+
+The `handlers` field of the configuration overrides the way in which event handlers, such as `fetch` or `queue`, are instrumented.
+
+#### Fetch Handler
+
+`acceptTraceContext` is used to specify if incoming requests handled by `fetch` should accept a TraceContext and participate in a distributed trace.
+The default is `true` for all incoming requests, but you can turn it off for all requests with `false` or specify a method that takes the incoming `Request` and returns a boolean indicating whether to accept the tracing context.
 
 Example:
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -109,6 +109,11 @@ function parseConfig(supplied: TraceConfig): ResolvedTraceConfig {
 		fetch: {
 			includeTraceContext: supplied.fetch?.includeTraceContext ?? true,
 		},
+		handlers: {
+			fetch: {
+				acceptTraceContext: supplied.handlers?.fetch?.acceptTraceContext ?? true,
+			},
+		},
 		postProcessor: supplied.postProcessor || ((spans: ReadableSpan[]) => spans),
 		sampling: {
 			headSampler,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,15 @@
 import { ReadableSpan, Sampler, SpanExporter } from '@opentelemetry/sdk-trace-base'
 import { OTLPExporterConfig } from './exporter.js'
-import { FetcherConfig } from './instrumentation/fetch.js'
+import { FetchHandlerConfig, FetcherConfig } from './instrumentation/fetch.js'
 import { TailSampleFn } from './sampling.js'
 
 export type PostProcessorFn = (spans: ReadableSpan[]) => ReadableSpan[]
 
 export type ExporterConfig = OTLPExporterConfig | SpanExporter
+
+export interface HandlerConfig {
+	fetch?: FetchHandlerConfig
+}
 
 export interface ServiceConfig {
 	name: string
@@ -26,6 +30,7 @@ export interface SamplingConfig<HS extends HeadSamplerConf = HeadSamplerConf> {
 
 export interface TraceConfig<EC extends ExporterConfig = ExporterConfig> {
 	exporter: EC
+	handlers?: HandlerConfig
 	fetch?: FetcherConfig
 	postProcessor?: PostProcessorFn
 	sampling?: SamplingConfig
@@ -34,6 +39,7 @@ export interface TraceConfig<EC extends ExporterConfig = ExporterConfig> {
 
 export interface ResolvedTraceConfig extends TraceConfig {
 	exporter: SpanExporter
+	handlers: Required<HandlerConfig>
 	fetch: Required<FetcherConfig>
 	postProcessor: PostProcessorFn
 	sampling: Required<SamplingConfig<Sampler>>


### PR DESCRIPTION
### Description
This PR resolves #26 by incorporating a new configuration segment for the `fetch` handler with an option for `acceptTraceContext`. This option will allow disabling the incoming distributed trace context propagation for all requests or for individual requests using a callback function.

### Testing

I manually tested this using the Workers example with the various options and `ConsoleSpanExporter` for confirming the trace and parent span are set correctly.

### Extras to review

- [ ] Is the configuration API naming intuitive and consistent?
- [ ] Do the README updates adequately explain the feature?
- [ ] Do the JSDoc comments provide enough context inline for understanding the option?