### PR TITLE
Fix types exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,14 @@
 	"types": "dist/esm/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/esm/index.d.ts",
-			"import": "./dist/esm/index.js",
-			"require": "./dist/cjs/index.js"
+			"import": {
+				"types": "./dist/esm/index.d.ts",
+				"default": "./dist/esm/index.js"
+			},
+			"require": {
+				"types": "./dist/cjs/index.d.ts",
+				"default": "./dist/cjs/index.js"
+			}
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
After the changes, here is the output of `pnpm run build && npm x --package=@arethetypeswrong/cli -c "attw $(pnpm pack)"`:

|                   | "@microlabs/otel-cf-workers" |
|-------------------|-------------------------------|
| node10            | 🟢                            |
| node16 (from CJS) | 🟢 (CJS)                      |
| node16 (from ESM) | 🟢 (ESM)                      |
| bundler           | 🟢                            |


Closes #29.