### PR TITLE
fix Durable Object storage.list with no args

### DIFF
--- a/src/instrumentation/do-storage.ts
+++ b/src/instrumentation/do-storage.ts
@@ -43,8 +43,11 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 		return attrs
 	},
 	list(argArray, result: Map<string, unknown>) {
-		const attrs = argArray[0]
-		attrs['do.storage.number_of_results'] = result.size
+		// list may be called with no arguments
+		const attrs: Attributes = {
+			'do.storage.number_of_results': result.size,
+		}
+		Object.assign(attrs, argArray[0])
 		return attrs
 	},
 	put(argArray) {


### PR DESCRIPTION
When calling `storage.list()` with no arguments, the instrumented `DurableObjectStorage` instance throws an error due to `attrs` being undefined. This PR modifies the attribute creation to create the object first, then merges incoming attributes if applicable.

closes #33 