### PR TITLE
Prefix KV instrumentation attributes, add cacheStatus

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"ts-checked-fsm": "^1.1.0"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20230628.0",
+		"@cloudflare/workers-types": "^4.20230807.0",
 		"rimraf": "^4.4.1",
 		"typescript": "^5.0.3"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ dependencies:
 
 devDependencies:
   '@cloudflare/workers-types':
-    specifier: ^4.20230628.0
-    version: 4.20230628.0
+    specifier: ^4.20230807.0
+    version: 4.20230807.0
   rimraf:
     specifier: ^4.4.1
     version: 4.4.1
@@ -45,8 +45,8 @@ devDependencies:
 
 packages:
 
-  /@cloudflare/workers-types@4.20230628.0:
-    resolution: {integrity: sha512-dpOFJJPEEWahLJKhj+xRY+VwXu/s/634CVsLVnTNDCfs2KXZx9nwQ/04M0OKBJFdc6jheWwAAv/AGvRvrTDkDg==}
+  /@cloudflare/workers-types@4.20230807.0:
+    resolution: {integrity: sha512-gQczWuGE2rxmpzOCNn0zLbx8Xz0gqspdE9S7tu4Xax39q1csgO/E9flcS+KG3GHB522ugOh84inmABDhpeJnvQ==}
     dev: true
 
   /@opentelemetry/api@1.4.1:

--- a/src/instrumentation/kv.ts
+++ b/src/instrumentation/kv.ts
@@ -38,10 +38,13 @@ const KVAttributes: Record<string | symbol, ExtraAttributeFn> = {
 		attrs['kv.list_prefix'] = prefix || undefined
 		attrs['kv.list_request_cursor'] = cursor || undefined
 		attrs['kv.list_limit'] = limit || undefined
-		const { list_complete } = result as KVNamespaceListResult<any, any>
+		const { list_complete, cacheStatus } = result as KVNamespaceListResult<any, any>
 		attrs['kv.list_complete'] = list_complete || undefined
 		if (!list_complete) {
 			attrs['kv.list_response_cursor'] = cursor || undefined
+		}
+		if (typeof cacheStatus === 'string') {
+		  attrs['kv.cacheStatus'] = cacheStatus
 		}
 		return attrs
 	},

--- a/src/instrumentation/kv.ts
+++ b/src/instrumentation/kv.ts
@@ -15,16 +15,16 @@ const KVAttributes: Record<string | symbol, ExtraAttributeFn> = {
 		}
 		const opts = argArray[1]
 		if (typeof opts === 'string') {
-			attrs['type'] = opts
+			attrs['kv.type'] = opts
 		} else if (typeof opts === 'object') {
-			attrs['type'] = opts.type
-			attrs['cacheTtl'] = opts.cacheTtl
+			attrs['kv.type'] = opts.type
+			attrs['kv.cacheTtl'] = opts.cacheTtl
 		}
 		return attrs
 	},
 	getWithMetadata(argArray, result) {
 		const attrs = this.get(argArray, result)
-		attrs['withMetadata'] = true
+		attrs['kv.withMetadata'] = true
 		return attrs
 	},
 	list(argArray, result) {

--- a/src/instrumentation/kv.ts
+++ b/src/instrumentation/kv.ts
@@ -25,6 +25,10 @@ const KVAttributes: Record<string | symbol, ExtraAttributeFn> = {
 	getWithMetadata(argArray, result) {
 		const attrs = this.get(argArray, result)
 		attrs['kv.withMetadata'] = true
+		const { cacheStatus } = result as KVNamespaceGetWithMetadataResult<any, any>
+		if (typeof cacheStatus === 'string') {
+		  attrs['kv.cacheStatus'] = cacheStatus
+		}
 		return attrs
 	},
 	list(argArray, result) {

--- a/src/instrumentation/kv.ts
+++ b/src/instrumentation/kv.ts
@@ -39,7 +39,7 @@ const KVAttributes: Record<string | symbol, ExtraAttributeFn> = {
 		attrs['kv.list_request_cursor'] = cursor || undefined
 		attrs['kv.list_limit'] = limit || undefined
 		const { list_complete } = result as KVNamespaceListResult<any, any>
-		attrs['kv.list_complete'] = limit || undefined
+		attrs['kv.list_complete'] = list_complete || undefined
 		if (!list_complete) {
 			attrs['kv.list_response_cursor'] = cursor || undefined
 		}


### PR DESCRIPTION
Implements most of #37 - except for replacing `get` with `getWithMetadata` under the hood:

- `workers-types` has been updated
- `cacheStatus` is now reported from `getWithMetadata` and `list`
- `list_complete` was reporting cursor instead of the boolean
- prefix attributes with `kv.`