### PR TITLE
Support multiple span processors

### DIFF
--- a/src/instrumentation/common.ts
+++ b/src/instrumentation/common.ts
@@ -53,7 +53,7 @@ export async function exportSpans(tracker?: PromiseTracker) {
 		if (tracker) {
 			await tracker.wait()
 		}
-		await tracer.spanProcessor.forceFlush()
+		await tracer.spanProcessors.forEach(sp => { sp.forceFlush() });
 	} else {
 		console.error('The global tracer is not of type WorkerTracer and can not export spans')
 	}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -14,19 +14,19 @@ import { WorkerTracer } from './tracer.js'
  * @param config Configuration object for SDK registration
  */
 export class WorkerTracerProvider implements TracerProvider {
-	private spanProcessor: SpanProcessor
+	private spanProcessors: SpanProcessor[]
 	private resource: Resource
 	private tracers: Record<string, Tracer> = {}
 
-	constructor(spanProcessor: SpanProcessor, resource: Resource) {
-		this.spanProcessor = spanProcessor
+	constructor(spanProcessors: SpanProcessor[], resource: Resource) {
+		this.spanProcessors = spanProcessors
 		this.resource = resource
 	}
 
 	getTracer(name: string, version?: string, options?: TracerOptions): Tracer {
 		const key = `${name}@${version || ''}:${options?.schemaUrl || ''}`
 		if (!this.tracers[key]) {
-			this.tracers[key] = new WorkerTracer(this.spanProcessor, this.resource)
+			this.tracers[key] = new WorkerTracer(this.spanProcessors, this.resource)
 		}
 		return this.tracers[key]
 	}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -72,8 +72,9 @@ function init(config: ResolvedTraceConfig): void {
 		instrumentGlobalFetch()
 		propagation.setGlobalPropagator(new W3CTraceContextPropagator())
 		const resource = createResource(config)
-		const spanProcessor = new BatchTraceSpanProcessor()
-		const provider = new WorkerTracerProvider(spanProcessor, resource)
+		config.spanProcessors.push(new BatchTraceSpanProcessor())
+
+		const provider = new WorkerTracerProvider(config.spanProcessors, resource)
 		provider.register()
 		initialised = true
 	}
@@ -119,6 +120,7 @@ function parseConfig(supplied: TraceConfig): ResolvedTraceConfig {
 			tailSampler: supplied.sampling?.tailSampler || multiTailSampler([isHeadSampled, isRootErrorSpan]),
 		},
 		service: supplied.service,
+		spanProcessors: supplied.spanProcessors || [],
 	}
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { ReadableSpan, Sampler, SpanExporter } from '@opentelemetry/sdk-trace-base'
+import { ReadableSpan, Sampler, SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { OTLPExporterConfig } from './exporter.js'
 import { FetchHandlerConfig, FetcherConfig } from './instrumentation/fetch.js'
 import { TailSampleFn } from './sampling.js'
@@ -35,6 +35,7 @@ export interface TraceConfig<EC extends ExporterConfig = ExporterConfig> {
 	postProcessor?: PostProcessorFn
 	sampling?: SamplingConfig
 	service: ServiceConfig
+	spanProcessors: SpanProcessor[]
 }
 
 export interface ResolvedTraceConfig extends TraceConfig {
@@ -43,6 +44,7 @@ export interface ResolvedTraceConfig extends TraceConfig {
 	fetch: Required<FetcherConfig>
 	postProcessor: PostProcessorFn
 	sampling: Required<SamplingConfig<Sampler>>
+	spanProcessors: SpanProcessor[]
 }
 
 export interface DOConstructorTrigger {


### PR DESCRIPTION
This PR attempts to close https://github.com/evanderkoogh/otel-cf-workers/issues/42. Not sure if you want this upstream @evanderkoogh, but I wanted to prove to myself it could be done, so here it is! Some demo code:

```ts
import { instrument, ResolveConfigFn } from '@microlabs/otel-cf-workers'
import { trace, Span, Context } from '@opentelemetry/api'
import { ConsoleSpanExporter, ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base'

class LoggingSpanProcessor implements SpanProcessor {
	onStart(span: Span, _parentContext: Context): void {
		console.log(`startspan:${span.spanContext().spanId}`)
	}

	onEnd(span: ReadableSpan): void {
		console.log(`endspan:${span.spanContext().spanId}`)
	}

	forceFlush(): Promise<void> {
		return Promise.resolve()
	}

	shutdown(): Promise<void> {
		return Promise.resolve()
	}
}

const ResolveTraceConfigFn: ResolveConfigFn = () => {
	return {
		exporter: new ConsoleSpanExporter,
		service: { name: 'greetings' },
		spanProcessors: [new LoggingSpanProcessor]
	}
}

const handler = {
	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
		await fetch('https://cloudflare.com')
		const greeting = "G'day World"
		trace.getActiveSpan()?.setAttribute('greeting', greeting)
		ctx.waitUntil(fetch('https://workers.dev'))
		return new Response(`${greeting}!`)
	},
}

export default instrument(handler, ResolveTraceConfigFn)
```