### PR TITLE
Implement Analytics Engine instrumentation

### DIFF
--- a/.changeset/new-gifts-repair.md
+++ b/.changeset/new-gifts-repair.md
@@ -1,0 +1,5 @@
+---
+'@microlabs/otel-cf-workers': minor
+---
+
+Add instrumentation for Analytics Engine bindings

--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ Bindings:
 - [x] Durable Objects
 - [ ] R2
 - [ ] D1
-- [ ] Service Bindings
-- [ ] Analytics Engine
+- [x] Service Bindings
+- [x] Analytics Engine
 - [ ] Browser Rendering
 - [ ] Workers AI
 - [ ] Email Sending

--- a/src/instrumentation/analytics-engine.ts
+++ b/src/instrumentation/analytics-engine.ts
@@ -1,0 +1,59 @@
+import { Attributes, SpanKind, SpanOptions, trace } from '@opentelemetry/api'
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions'
+import { wrap } from '../wrap.js'
+
+type ExtraAttributeFn = (argArray: any[], result: any) => Attributes
+
+const dbSystem = 'Cloudflare Analytics Engine'
+
+const AEAttributes: Record<string | symbol, ExtraAttributeFn> = {
+	writeDataPoint(argArray) {
+		const attrs: Attributes = {}
+		const opts = argArray[0]
+		if (typeof opts === 'object') {
+			attrs['db.cf.ae.indexes'] = opts.indexes.length,
+			attrs['db.cf.ae.index'] = (opts.indexes[0] as (ArrayBuffer | string)).toString(),
+			attrs['db.cf.ae.doubles'] = opts.doubles.length,
+			attrs['db.cf.ae.blobs'] = opts.blobs.length
+		}
+		return attrs
+	}
+}
+
+function instrumentAEFn(fn: Function, name: string, operation: string) {
+	const tracer = trace.getTracer('AnalyticsEngine')
+	const fnHandler: ProxyHandler<any> = {
+		apply: (target, thisArg, argArray) => {
+			const attributes = {
+				binding_type: 'AnalyticsEngine',
+				[SemanticAttributes.DB_NAME]: name,
+				[SemanticAttributes.DB_SYSTEM]: dbSystem,
+				[SemanticAttributes.DB_OPERATION]: operation,
+			}
+			const options: SpanOptions = {
+				kind: SpanKind.CLIENT,
+				attributes,
+			}
+			return tracer.startActiveSpan(`${name} ${operation}`, options, async (span) => {
+				const result = await Reflect.apply(target, thisArg, argArray)
+				const extraAttrs = AEAttributes[operation] ? AEAttributes[operation](argArray, result) : {}
+				span.setAttributes(extraAttrs)
+				span.setAttribute(SemanticAttributes.DB_STATEMENT, `${operation} ${argArray[0]}`)
+				span.end()
+				return result
+			})
+		},
+	}
+	return wrap(fn, fnHandler)
+}
+
+export function instrumentAnalyticsEngineDataset(dataset: AnalyticsEngineDataset, name: string): AnalyticsEngineDataset {
+	const datasetHandler: ProxyHandler<AnalyticsEngineDataset> = {
+		get: (target, prop, receiver) => {
+			const operation = String(prop)
+			const fn = Reflect.get(target, prop, receiver)
+			return instrumentAEFn(fn, name, operation)
+		},
+	}
+	return wrap(dataset, datasetHandler)
+}

--- a/src/instrumentation/analytics-engine.ts
+++ b/src/instrumentation/analytics-engine.ts
@@ -11,9 +11,9 @@ const AEAttributes: Record<string | symbol, ExtraAttributeFn> = {
 		const attrs: Attributes = {}
 		const opts = argArray[0]
 		if (typeof opts === 'object') {
-			attrs['db.cf.ae.indexes'] = opts.indexes.length,
-			attrs['db.cf.ae.index'] = (opts.indexes[0] as (ArrayBuffer | string)).toString(),
-			attrs['db.cf.ae.doubles'] = opts.doubles.length,
+			attrs['db.cf.ae.indexes'] = opts.indexes.length
+			attrs['db.cf.ae.index'] = (opts.indexes[0] as (ArrayBuffer | string)).toString()
+			attrs['db.cf.ae.doubles'] = opts.doubles.length
 			attrs['db.cf.ae.blobs'] = opts.blobs.length
 		}
 		return attrs

--- a/src/instrumentation/env.ts
+++ b/src/instrumentation/env.ts
@@ -3,6 +3,7 @@ import { instrumentDOBinding } from './do.js'
 import { instrumentKV } from './kv.js'
 import { instrumentQueueSender } from './queue.js'
 import { instrumentServiceBinding } from './service.js'
+import { instrumentAnalyticsEngineDataset } from './analytics-engine'
 
 const isKVNamespace = (item?: unknown): item is KVNamespace => {
 	return !!(item as KVNamespace)?.getWithMetadata
@@ -21,6 +22,10 @@ const isServiceBinding = (item?: unknown): item is Fetcher => {
 	return !!binding.connect || !!binding.fetch || binding.queue || binding.scheduled
 }
 
+const isAnalyticsEngineDataset = (item?: unknown): item is AnalyticsEngineDataset => {
+	return !!(item as AnalyticsEngineDataset)?.writeDataPoint
+}
+
 const instrumentEnv = (env: Record<string, unknown>): Record<string, unknown> => {
 	const envHandler: ProxyHandler<Record<string, unknown>> = {
 		get: (target, prop, receiver) => {
@@ -36,6 +41,8 @@ const instrumentEnv = (env: Record<string, unknown>): Record<string, unknown> =>
 				return instrumentDOBinding(item, String(prop))
 			} else if (isServiceBinding(item)) {
 				return instrumentServiceBinding(item, String(prop))
+			} else if (isAnalyticsEngineDataset(item)) {
+				return instrumentAnalyticsEngineDataset(item, String(prop))
 			} else {
 				return item
 			}


### PR DESCRIPTION
This PR implements instrumentation for Analytics Engine datasets. Couple of questions:
- The current code records the number of indexes (which is limited to 1 by the runtime) and the first index. This index can be an arraybuffer, which isn't "portable" so right now I just call `.toString`. Any recommendatons for that, if nothing else we can use a `TextDecoder` to get some log-friendly text out of it.
- Please double-check the names of tracers, dbs, basically all string constants.

Also this PR needs some testing before I'm confident merging it.