### PR TITLE
[fix] support hrtime tuple as TimeInput instead of throwing

### DIFF
--- a/src/span.ts
+++ b/src/span.ts
@@ -70,9 +70,12 @@ function getHrTime(input?: TimeInput): HrTime {
 	} else if (typeof input === 'number') {
 		//TODO: do something with performance.now something
 		return millisToHr(input)
-	} else {
-		throw new Error('No valid time')
+	} else if (Array.isArray(input)) {
+		return input
 	}
+
+	const v: never = input
+	throw new Error(`unreachable value: ${JSON.stringify(v)}`)
 }
 
 export class SpanImpl implements Span, ReadableSpan {


### PR DESCRIPTION
when providing a TimeInput that is , this
library crashes. However, it is a totally safe input and
it's easy to normalize: we just do nothing.

This is happening when using Effect.ts (https://effect.website)
with this library as an exporter.
