### PR TITLE
Fix span.end() call for scheduled tracing

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
 	"dependencies": {
 		"@opentelemetry/api": "^1.6.0",
 		"@opentelemetry/core": "^1.17.1",
-		"@opentelemetry/exporter-trace-otlp-http": "^0.36.1",
-		"@opentelemetry/otlp-exporter-base": "^0.36.1",
-		"@opentelemetry/otlp-transformer": "^0.36.1",
+		"@opentelemetry/exporter-trace-otlp-http": "^0.44.0",
+		"@opentelemetry/otlp-exporter-base": "^0.44.0",
+		"@opentelemetry/otlp-transformer": "^0.44.0",
 		"@opentelemetry/resources": "^1.17.1",
 		"@opentelemetry/sdk-trace-base": "^1.17.1",
 		"@opentelemetry/semantic-conventions": "^1.17.1",

--- a/src/instrumentation/scheduled.ts
+++ b/src/instrumentation/scheduled.ts
@@ -36,8 +36,9 @@ export function executeScheduledHandler(
 		} catch (error) {
 			span.recordException(error as Exception)
 			span.setStatus({ code: SpanStatusCode.ERROR })
-			span.end()
 			throw error
+		} finally {
+			span.end()
 		}
 	})
 	return promise


### PR DESCRIPTION
I noticed span.end() was only being called in the case of failures so we where not getting any data for scheduled invocations.

I also bumped the dependencies oltp-http, exporter-base and transformer to 0.44.0 so the peer deps of `@opentelemetry/api` are in the correct version range and and I can install packages without peer dep warnings
