### PR TITLE
Tidy dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,14 +38,13 @@
 		"@opentelemetry/resources": "^1.17.1",
 		"@opentelemetry/sdk-trace-base": "^1.17.1",
 		"@opentelemetry/semantic-conventions": "^1.17.1",
-		"deepmerge": "^4.3.1",
-		"husky": "^8.0.3",
-		"lint-staged": "^15.0.2",
 		"ts-checked-fsm": "^1.1.0"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.26.2",
 		"@cloudflare/workers-types": "^4.20231016.0",
+		"husky": "^8.0.3",
+		"lint-staged": "^15.0.2",
 		"prettier": "^3.0.3",
 		"rimraf": "^4.4.1",
 		"typescript": "^5.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,15 +29,6 @@ dependencies:
   '@opentelemetry/semantic-conventions':
     specifier: ^1.17.1
     version: 1.17.1
-  deepmerge:
-    specifier: ^4.3.1
-    version: 4.3.1
-  husky:
-    specifier: ^8.0.3
-    version: 8.0.3
-  lint-staged:
-    specifier: ^15.0.2
-    version: 15.0.2
   ts-checked-fsm:
     specifier: ^1.1.0
     version: 1.1.0
@@ -49,6 +40,12 @@ devDependencies:
   '@cloudflare/workers-types':
     specifier: ^4.20231016.0
     version: 4.20231016.0
+  husky:
+    specifier: ^8.0.3
+    version: 8.0.3
+  lint-staged:
+    specifier: ^15.0.2
+    version: 15.0.2
   prettier:
     specifier: ^3.0.3
     version: 3.0.3
@@ -798,11 +795,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
     dependencies:
@@ -1217,7 +1209,7 @@ packages:
     resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: false
+    dev: true
 
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -1462,7 +1454,7 @@ packages:
       yaml: 2.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /listr2@7.0.2:
     resolution: {integrity: sha512-rJysbR9GKIalhTbVL2tYbF2hVyDnrf7pFUZBwjPaMIdadYHmeT+EVi/Bu3qd7ETQPahTotg2WRCatXwRBW554g==}


### PR DESCRIPTION
use of `deepmerge` was removed in https://github.com/evanderkoogh/otel-cf-workers/commit/5a807181698daa2b970a3032d1c6576f8d9288f5

`husky` and `lint-staged` -> devDependencies