### PR TITLE
fix: Remove top-level concurrency in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
-
 jobs:
   release:
     name: Release


### PR DESCRIPTION
The release workflow is broke due to a deadlock caused by having two concurrency checks