### PR TITLE
fix: Inline kv.getWithMetadata() attributes to prevent exception

### DIFF
--- a/.changeset/big-news-lick.md
+++ b/.changeset/big-news-lick.md
@@ -1,0 +1,8 @@
+---
+'@microlabs/otel-cf-workers': patch
+---
+
+fix: Inline kv.getWithMetadata() attributes to prevent exception
+
+KVAttributes functions don't have access to other functions, so we
+needed to inline functionality from get(argArray)

--- a/src/instrumentation/kv.ts
+++ b/src/instrumentation/kv.ts
@@ -22,7 +22,15 @@ const KVAttributes: Record<string | symbol, ExtraAttributeFn> = {
 		return attrs
 	},
 	getWithMetadata(argArray, result) {
-		const attrs = this['get']!(argArray, result)
+		const attrs: Attributes = {}
+		const opts = argArray[1]
+		if (typeof opts === 'string') {
+			attrs['db.cf.kv.type'] = opts
+		} else if (typeof opts === 'object') {
+			attrs['db.cf.kv.type'] = opts.type
+			attrs['db.cf.kv.cache_ttl'] = opts.cacheTtl
+		}
+
 		attrs['db.cf.kv.metadata'] = true
 		const { cacheStatus } = result as KVNamespaceGetWithMetadataResult<any, any>
 		if (typeof cacheStatus === 'string') {


### PR DESCRIPTION
KVAttributes functions don't have access to other functions, so we needed to inline functionality from get(argArray)

Fixes # [insert GH issue number(s)].

**What this PR solves / how to test:**
Tested in a Worker that calls getWithMetadata and confirmed it no longer crashes