### PR TITLE
fix: Set has_result to false when there is no value returned in kv.getWithMetadata()

### DIFF
--- a/.changeset/polite-days-rush.md
+++ b/.changeset/polite-days-rush.md
@@ -1,0 +1,5 @@
+---
+'@microlabs/otel-cf-workers': patch
+---
+
+fix: Set has_result to false when there is no value returned in kv.getWithMetadata()

--- a/src/instrumentation/kv.ts
+++ b/src/instrumentation/kv.ts
@@ -93,7 +93,12 @@ function instrumentKVFn(fn: Function, name: string, operation: string) {
 					span.setAttribute(SemanticAttributes.DB_STATEMENT, `${operation} ${argArray[0]}`)
 					span.setAttribute('db.cf.kv.key', argArray[0])
 				}
-				span.setAttribute('db.cf.kv.has_result', !!result)
+				if (operation === 'getWithMetadata') {
+					const hasResults = !!result && !!(result as KVNamespaceGetWithMetadataResult<string, unknown>).value
+					span.setAttribute('db.cf.kv.has_result', hasResults)
+				} else {
+					span.setAttribute('db.cf.kv.has_result', !!result)
+				}
 				span.end()
 				return result
 			})


### PR DESCRIPTION
We currently set has_result to true because getWithMetadata always returns an object with value/metadata even if the key didn't exist.

This should still return true when the key has an empty value because `!!emptyString = true`