### PR TITLE
fix: extensionless js imports

### DIFF
--- a/src/instrumentation/env.ts
+++ b/src/instrumentation/env.ts
@@ -3,7 +3,7 @@ import { instrumentDOBinding } from './do.js'
 import { instrumentKV } from './kv.js'
 import { instrumentQueueSender } from './queue.js'
 import { instrumentServiceBinding } from './service.js'
-import { instrumentAnalyticsEngineDataset } from './analytics-engine'
+import { instrumentAnalyticsEngineDataset } from './analytics-engine.js'
 
 const isKVNamespace = (item?: unknown): item is KVNamespace => {
 	return !!(item as KVNamespace)?.getWithMetadata

--- a/src/instrumentation/service.ts
+++ b/src/instrumentation/service.ts
@@ -1,5 +1,5 @@
-import { passthroughGet, wrap } from '../wrap'
-import { instrumentClientFetch } from './fetch'
+import { passthroughGet, wrap } from '../wrap.js'
+import { instrumentClientFetch } from './fetch.js'
 
 export function instrumentServiceBinding(fetcher: Fetcher, envName: string): Fetcher {
 	const fetcherHandler: ProxyHandler<Fetcher> = {


### PR DESCRIPTION
It seems, that there are still some imports left in code, that have no exact extensions. This is not supported by node module resolution process:
[Node API - file extensions](https://nodejs.org/api/esm.html#mandatory-file-extensions)

#### Why and where it is usually a problem ?
When running otel-cf-workers code not in the ***bundled*** form (together with worker code), particularly in ***unit tests***.

#### Why it is not noticable and was not mentioned a lot of times before ?
I think, that is exactly due to the previous point: running a Cloudflare worker (even locally) usually includes a bundling step, by esbuild. And, possibly, exactly the bundler solves all the problems with having incorrect import signatures.

But, when writing __unit-tests__ for the workers (if you do not use a bundle at all), that becomes a problem - and module resolutions fails with console errors (in my case, it is the **mocha** framework):

![image](https://github.com/evanderkoogh/otel-cf-workers/assets/46961971/e87a25f3-3a5e-4ce4-9f0c-e65907ad9297)

#### Important - this is a direct continuation of a previously raised issue:
[ESM interoperability question](https://github.com/evanderkoogh/otel-cf-workers/issues/16), which as I think, was closed without a real resolution (unfortunately). I also think, we need to *re-think* and fix all issues mentioned in that issue.
