### PR TITLE
Fix telemetry sdk attributes

### DIFF
--- a/.changeset/cuddly-cars-give.md
+++ b/.changeset/cuddly-cars-give.md
@@ -1,0 +1,5 @@
+---
+"@microlabs/otel-cf-workers": patch
+---
+
+Fix telemetry sdk attributes

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -29,6 +29,7 @@ import { instrumentGlobalCache } from './instrumentation/cache.js'
 import { createQueueHandler } from './instrumentation/queue.js'
 import { DOClass, instrumentDOClass } from './instrumentation/do.js'
 import { createScheduledHandler } from './instrumentation/scheduled.js'
+import { name, version } from '../package.json'
 
 type FetchHandler = ExportedHandlerFetchHandler<unknown, unknown>
 type ScheduledHandler = ExportedHandlerScheduledHandler<unknown>
@@ -56,7 +57,8 @@ const createResource = (config: ResolvedTraceConfig): Resource => {
 		'cloud.region': 'earth',
 		'faas.max_memory': 134217728,
 		'telemetry.sdk.language': 'js',
-		'telemetry.sdk.name': '@microlabs/otel-workers-sdk',
+		'telemetry.sdk.name': name,
+		'telemetry.sdk.version': version,
 	}
 	const serviceResource = new Resource({
 		'service.name': config.service.name,


### PR DESCRIPTION
Fixes # [insert GH issue number(s)].

**What this PR solves / how to test:**

This PR adds the missing `telemetry.sdk.version` attribute which is required by the spec: https://opentelemetry.io/docs/specs/otel/semantic-conventions/

Importing it from package.json will make sure it's updated automatically, assuming the build command is run after the version in package.json is incremented by changesets.