### PR TITLE
Add more DO storage instrumentation

### DIFF
--- a/.changeset/polite-dots-scream.md
+++ b/.changeset/polite-dots-scream.md
@@ -1,0 +1,5 @@
+---
+"@microlabs/otel-cf-workers": patch
+---
+
+Fix DO storage instrumentation extra attributes

--- a/.changeset/polite-schools-sip.md
+++ b/.changeset/polite-schools-sip.md
@@ -1,0 +1,5 @@
+---
+"@microlabs/otel-cf-workers": patch
+---
+
+Fix DO storage put when providing an object with multiple values

--- a/.changeset/tiny-buckets-behave.md
+++ b/.changeset/tiny-buckets-behave.md
@@ -1,0 +1,5 @@
+---
+"@microlabs/otel-cf-workers": minor
+---
+
+Add instrumentation for DO storage alarm methods and deleteAll

--- a/src/instrumentation/common.ts
+++ b/src/instrumentation/common.ts
@@ -72,3 +72,13 @@ async function allSettledMutable(promises: Promise<unknown>[]): Promise<PromiseS
 	} while (values.length !== promises.length)
 	return values
 }
+
+/** Overloads extracts up to 4 overloads for the given function. */
+export type Overloads<T> = T extends {
+	(...args: infer P1): infer R1
+	(...args: infer P2): infer R2
+	(...args: infer P3): infer R3
+	(...args: infer P4): infer R4
+}
+	? ((...args: P1) => R1) | ((...args: P2) => R2) | ((...args: P3) => R3) | ((...args: P4) => R4)
+	: never

--- a/src/instrumentation/do-storage.ts
+++ b/src/instrumentation/do-storage.ts
@@ -63,7 +63,7 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 			}
 		}
 		if (argArray.length > 1) {
-			const options = argArray[1] as DurableObjectPutOptions
+			const options = argArray[1] as DurableObjectGetOptions
 			if ('allowConcurrency' in options) {
 				attrs['db.cf.do.allow_concurrency'] = options.allowConcurrency
 			}
@@ -78,7 +78,7 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 			'db.cf.do.number_of_results': result.size,
 		} as Record<string, string | number | boolean | undefined>
 		if (argArray.length > 0) {
-			const options = argArray[0] as DurableObjectPutOptions
+			const options = argArray[0] as DurableObjectListOptions
 			if ('allowConcurrency' in options) {
 				attrs['db.cf.do.allow_concurrency'] = options.allowConcurrency
 			}
@@ -86,22 +86,22 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 				attrs['db.cf.do.no_cache'] = options.noCache
 			}
 			if ('start' in options) {
-				attrs['db.cf.do.start'] = options.noCache
+				attrs['db.cf.do.start'] = options.start
 			}
 			if ('startAfter' in options) {
-				attrs['db.cf.do.start_after'] = options.noCache
+				attrs['db.cf.do.start_after'] = options.startAfter
 			}
 			if ('end' in options) {
-				attrs['db.cf.do.end'] = options.noCache
+				attrs['db.cf.do.end'] = options.end
 			}
 			if ('prefix' in options) {
-				attrs['db.cf.do.prefix'] = options.noCache
+				attrs['db.cf.do.prefix'] = options.prefix
 			}
 			if ('reverse' in options) {
-				attrs['db.cf.do.reverse'] = options.noCache
+				attrs['db.cf.do.reverse'] = options.reverse
 			}
 			if ('limit' in options) {
-				attrs['db.cf.do.limit'] = options.noCache
+				attrs['db.cf.do.limit'] = options.limit
 			}
 		}
 		return attrs
@@ -153,7 +153,7 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 			attrs['db.cf.do.alarm_time'] = argArray[0]
 		}
 		if (argArray.length > 1) {
-			const options = argArray[1] as DurableObjectPutOptions
+			const options = argArray[1] as DurableObjectSetAlarmOptions
 			if ('allowConcurrency' in options) {
 				attrs['db.cf.do.allow_concurrency'] = options.allowConcurrency
 			}
@@ -166,7 +166,7 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 	deleteAlarm(argArray) {
 		const attrs = {} as Record<string, string | number | boolean | undefined>
 		if (argArray.length > 0) {
-			const options = argArray[0] as DurableObjectPutOptions
+			const options = argArray[0] as DurableObjectSetAlarmOptions
 			if ('allowConcurrency' in options) {
 				attrs['db.cf.do.allow_concurrency'] = options.allowConcurrency
 			}

--- a/src/instrumentation/do-storage.ts
+++ b/src/instrumentation/do-storage.ts
@@ -74,11 +74,36 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 		return attrs
 	},
 	list(argArray, result: Map<string, unknown>) {
-		// list may be called with no arguments
 		const attrs: Attributes = {
 			'db.cf.do.number_of_results': result.size,
 		} as Record<string, string | number | boolean | undefined>
-		Object.assign(attrs, argArray[0])
+		if (argArray.length > 0) {
+			const options = argArray[0] as DurableObjectPutOptions
+			if ('allowConcurrency' in options) {
+				attrs['db.cf.do.allow_concurrency'] = options.allowConcurrency
+			}
+			if ('noCache' in options) {
+				attrs['db.cf.do.no_cache'] = options.noCache
+			}
+			if ('start' in options) {
+				attrs['db.cf.do.start'] = options.noCache
+			}
+			if ('startAfter' in options) {
+				attrs['db.cf.do.start_after'] = options.noCache
+			}
+			if ('end' in options) {
+				attrs['db.cf.do.end'] = options.noCache
+			}
+			if ('prefix' in options) {
+				attrs['db.cf.do.prefix'] = options.noCache
+			}
+			if ('reverse' in options) {
+				attrs['db.cf.do.reverse'] = options.noCache
+			}
+			if ('limit' in options) {
+				attrs['db.cf.do.limit'] = options.noCache
+			}
+		}
 		return attrs
 	},
 	put(argArray) {
@@ -122,6 +147,11 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 	},
 	setAlarm(argArray) {
 		const attrs = {} as Record<string, string | number | boolean | undefined>
+		if (argArray[0] instanceof Date) {
+			attrs['db.cf.do.alarm_time'] = argArray[0].getTime()
+		} else {
+			attrs['db.cf.do.alarm_time'] = argArray[0]
+		}
 		if (argArray.length > 1) {
 			const options = argArray[1] as DurableObjectPutOptions
 			if ('allowConcurrency' in options) {

--- a/src/instrumentation/do-storage.ts
+++ b/src/instrumentation/do-storage.ts
@@ -8,7 +8,7 @@ const dbSystem = 'Cloudflare DO'
 
 const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 	delete(argArray, result) {
-		let attrs = {}
+		let attrs = {} as Record<string, string | number | boolean | undefined>
 		if (Array.isArray(argArray[0])) {
 			const keys = argArray[0]
 			attrs = {
@@ -23,12 +23,34 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 			}
 		}
 		if (argArray.length > 1) {
-			Object.assign(attrs, argArray[1])
+			const options = argArray[1] as DurableObjectPutOptions
+			if ('allowConcurrency' in options) {
+				attrs['db.cf.do.allow_concurrency'] = options.allowConcurrency
+			}
+			if ('allowUnconfirmed' in options) {
+				attrs['db.cf.do.allow_unconfirmed'] = options.allowUnconfirmed
+			}
+			if ('noCache' in options) {
+				attrs['db.cf.do.no_cache'] = options.noCache
+			}
+		}
+		return attrs
+	},
+	deleteAll(argArray) {
+		let attrs = {} as Record<string, string | number | boolean | undefined>
+		if (argArray.length > 0) {
+			const options = argArray[0] as DurableObjectPutOptions
+			if ('allowUnconfirmed' in options) {
+				attrs['db.cf.do.allow_unconfirmed'] = options.allowUnconfirmed
+			}
+			if ('noCache' in options) {
+				attrs['db.cf.do.no_cache'] = options.noCache
+			}
 		}
 		return attrs
 	},
 	get(argArray) {
-		let attrs = {}
+		let attrs = {} as Record<string, string | number | boolean | undefined>
 		if (Array.isArray(argArray[0])) {
 			const keys = argArray[0]
 			attrs = {
@@ -41,7 +63,13 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 			}
 		}
 		if (argArray.length > 1) {
-			Object.assign(attrs, argArray[1])
+			const options = argArray[1] as DurableObjectPutOptions
+			if ('allowConcurrency' in options) {
+				attrs['db.cf.do.allow_concurrency'] = options.allowConcurrency
+			}
+			if ('noCache' in options) {
+				attrs['db.cf.do.no_cache'] = options.noCache
+			}
 		}
 		return attrs
 	},
@@ -49,17 +77,72 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 		// list may be called with no arguments
 		const attrs: Attributes = {
 			'db.cf.do.number_of_results': result.size,
-		}
+		} as Record<string, string | number | boolean | undefined>
 		Object.assign(attrs, argArray[0])
 		return attrs
 	},
 	put(argArray) {
 		const attrs = {
 			'db.cf.do.key': argArray[0],
+		} as Record<string, string | number | boolean | undefined>
+
+		if (typeof argArray[0] === 'string') {
+			attrs['db.cf.do.key'] = argArray[0]
+		} else {
+			const keys = Object.keys(argArray[0])
+			attrs['db.cf.do.key'] = keys[0]
+			attrs['db.cf.do.number_of_keys'] = keys.length
 		}
 
-		if (argArray.length > 2) {
-			Object.assign(attrs, argArray[2])
+		const optionsIndex = typeof argArray[1] === 'object' ? 1 : 2
+
+		if (argArray.length > optionsIndex) {
+			const options = argArray[optionsIndex] as DurableObjectPutOptions
+			if ('allowConcurrency' in options) {
+				attrs['db.cf.do.allow_concurrency'] = options.allowConcurrency
+			}
+			if ('allowUnconfirmed' in options) {
+				attrs['db.cf.do.allow_unconfirmed'] = options.allowUnconfirmed
+			}
+			if ('noCache' in options) {
+				attrs['db.cf.do.no_cache'] = options.noCache
+			}
+		}
+		return attrs
+	},
+	getAlarm(argArray) {
+		let attrs = {} as Record<string, string | number | boolean | undefined>
+		if (argArray.length > 0) {
+			const options = argArray[0] as DurableObjectPutOptions
+			if ('allowConcurrency' in options) {
+				attrs['db.cf.do.allow_concurrency'] = options.allowConcurrency
+			}
+		}
+		return attrs
+	},
+	setAlarm(argArray) {
+		const attrs = {} as Record<string, string | number | boolean | undefined>
+		if (argArray.length > 1) {
+			const options = argArray[1] as DurableObjectPutOptions
+			if ('allowConcurrency' in options) {
+				attrs['db.cf.do.allow_concurrency'] = options.allowConcurrency
+			}
+			if ('allowUnconfirmed' in options) {
+				attrs['db.cf.do.allow_unconfirmed'] = options.allowUnconfirmed
+			}
+		}
+		return attrs
+	},
+	deleteAlarm(argArray) {
+		const attrs = {} as Record<string, string | number | boolean | undefined>
+		if (argArray.length > 0) {
+			const options = argArray[0] as DurableObjectPutOptions
+			if ('allowConcurrency' in options) {
+				attrs['db.cf.do.allow_concurrency'] = options.allowConcurrency
+			}
+			if ('allowUnconfirmed' in options) {
+				attrs['db.cf.do.allow_unconfirmed'] = options.allowUnconfirmed
+			}
 		}
 		return attrs
 	},

--- a/src/instrumentation/do-storage.ts
+++ b/src/instrumentation/do-storage.ts
@@ -105,17 +105,16 @@ const StorageAttributes: Record<string | symbol, ExtraAttributeFn> = {
 		const attrs: Attributes = {
 			'db.cf.do.key': argArray[0],
 		}
-
+		let optionsIndex = 1 // put(entries, options)
 		if (typeof argArray[0] === 'string') {
 			attrs['db.cf.do.key'] = argArray[0]
+			optionsIndex = 2 // put(key, value, options)
 		} else {
 			const keys = Object.keys(argArray[0])
 			// todo: Maybe set db.cf.do.keys to the whole array here?
 			attrs['db.cf.do.key'] = keys[0]
 			attrs['db.cf.do.number_of_keys'] = keys.length
 		}
-
-		const optionsIndex = typeof argArray[1] === 'object' ? 1 : 2
 
 		if (argArray.length > optionsIndex) {
 			const options = argArray[optionsIndex] as DurableObjectPutOptions


### PR DESCRIPTION
Fixes # [insert GH issue number(s)].

**What this PR solves / how to test:**

Previously, DO instrumentation copied all options to `attributes`. This PR implements special support for most methods (`transaction` is the only currently existing method on `DurableObjectStorage` that isn't handled properly, as it has a rollback method we should ideally proxy/track).

I also fixed a bug in `put`, pretty sure that the "entries" overload would've caused an exception previously as the instrumentation wasn't prepared for it.
