### PR TITLE
Make ResolveConfigFn type generic

### DIFF
--- a/.changeset/rude-bottles-jog.md
+++ b/.changeset/rude-bottles-jog.md
@@ -1,0 +1,5 @@
+---
+"@microlabs/otel-cf-workers": patch
+---
+
+Make ResolveConfigFn generic

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -34,7 +34,7 @@ type FetchHandler = ExportedHandlerFetchHandler<unknown, unknown>
 type ScheduledHandler = ExportedHandlerScheduledHandler<unknown>
 type QueueHandler = ExportedHandlerQueueHandler
 
-export type ResolveConfigFn = (env: any, trigger: Trigger) => TraceConfig
+export type ResolveConfigFn<Env = any> = (env: Env, trigger: Trigger) => TraceConfig
 export type ConfigurationOption = TraceConfig | ResolveConfigFn
 
 export function isRequest(trigger: Trigger): trigger is Request {


### PR DESCRIPTION
Fixes # [insert GH issue number(s)].

**What this PR solves / how to test:**

When setting up a new worker today, I copied the otel config resolver from another project. Unfortunately, the secret containing the api key had a different name there than I intended having in the new worker.

ResolveConfigFn previously had `env: any`, which means ts didn't catch this error. It now accepts an optional type parameter which allows users to typecheck their config resolver function better.