### PR TITLE
Improve version metadata binding detection

### DIFF
--- a/.changeset/tasty-ghosts-tickle.md
+++ b/.changeset/tasty-ghosts-tickle.md
@@ -1,0 +1,5 @@
+---
+"@microlabs/otel-cf-workers": patch
+---
+
+Correctly detect version metadata when tag is an empty string. Also, check for RPC bindings in all cases as `isVersionMetadata` was incorrectly picking up rpc bindings too when searching for version bindings.

--- a/src/instrumentation/env.ts
+++ b/src/instrumentation/env.ts
@@ -11,20 +11,20 @@ const isJSRPC = (item?: unknown): item is Service => {
 }
 
 const isKVNamespace = (item?: unknown): item is KVNamespace => {
-	return !!(item as KVNamespace)?.getWithMetadata
+	return !isJSRPC(item) && !!(item as KVNamespace)?.getWithMetadata
 }
 
 const isQueue = (item?: unknown): item is Queue<unknown> => {
-	return !!(item as Queue<unknown>)?.sendBatch
+	return !isJSRPC(item) && !!(item as Queue<unknown>)?.sendBatch
 }
 
 const isDurableObject = (item?: unknown): item is DurableObjectNamespace => {
-	return !!(item as DurableObjectNamespace)?.idFromName
+	return !isJSRPC(item) && !!(item as DurableObjectNamespace)?.idFromName
 }
 
 const isServiceBinding = (item?: unknown): item is Fetcher => {
 	const binding = item as Fetcher
-	return !!binding.connect || !!binding.fetch || binding.queue || binding.scheduled
+	return (!isJSRPC(item) && !!binding.connect) || !!binding.fetch || binding.queue || binding.scheduled
 }
 
 export const isVersionMetadata = (item?: unknown): item is WorkerVersionMetadata => {
@@ -36,7 +36,7 @@ export const isVersionMetadata = (item?: unknown): item is WorkerVersionMetadata
 }
 
 const isAnalyticsEngineDataset = (item?: unknown): item is AnalyticsEngineDataset => {
-	return !!(item as AnalyticsEngineDataset)?.writeDataPoint
+	return !isJSRPC(item) && !!(item as AnalyticsEngineDataset)?.writeDataPoint
 }
 
 const instrumentEnv = (env: Record<string, unknown>): Record<string, unknown> => {

--- a/src/instrumentation/env.ts
+++ b/src/instrumentation/env.ts
@@ -28,7 +28,11 @@ const isServiceBinding = (item?: unknown): item is Fetcher => {
 }
 
 export const isVersionMetadata = (item?: unknown): item is WorkerVersionMetadata => {
-	return !!(item as WorkerVersionMetadata).id && !!(item as WorkerVersionMetadata).tag
+	return (
+		!isJSRPC(item) &&
+		typeof (item as WorkerVersionMetadata).id === 'string' &&
+		typeof (item as WorkerVersionMetadata).tag === 'string'
+	)
 }
 
 const isAnalyticsEngineDataset = (item?: unknown): item is AnalyticsEngineDataset => {


### PR DESCRIPTION
Fixes # [insert GH issue number(s)].

**What this PR solves / how to test:**

Since the introduction of JSRPC bindings, the `versionAttributes` function was also picking those up as potential version metadata bindings. This implementation of the binding search should allow tag to be an empty string (which it is by default), so detection should also be more thorough.