### PR TITLE
Add extra resource attributes to config

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -65,7 +65,8 @@ const createResource = (config: ResolvedTraceConfig): Resource => {
 		'service.namespace': config.service.namespace,
 		'service.version': config.service.version,
 	})
-	const resource = new Resource(workerResourceAttrs)
+	const resourceAttributes = Object.assign({}, workerResourceAttrs, config.extraResourceAttributes)
+	const resource = new Resource(resourceAttributes)
 	return resource.merge(serviceResource)
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { TextMapPropagator } from '@opentelemetry/api'
+import { ResourceAttributes } from '@opentelemetry/resources'
 import { ReadableSpan, Sampler, SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { OTLPExporterConfig } from './exporter.js'
 import { FetchHandlerConfig, FetcherConfig } from './instrumentation/fetch.js'
@@ -31,6 +32,7 @@ export interface SamplingConfig<HS extends HeadSamplerConf = HeadSamplerConf> {
 
 interface TraceConfigBase {
 	service: ServiceConfig
+	extraResourceAttributes?: ResourceAttributes
 	handlers?: HandlerConfig
 	fetch?: FetcherConfig
 	postProcessor?: PostProcessorFn


### PR DESCRIPTION
Currently, there is no API to insert custom resource attributes.\
For example, to set `deployment.environment` semantic attribute from OpenTelemetry Semantic Conventions, one has to do smth like:
```js
		postProcessor: (spans) => {
			if (spans.length == 0) {
				return spans;
			}
			const resource = spans[0].resource;
			resource.attributes['deployment.environment'] = env.ENV_NAME;
			return spans;
		}
```

Ideally, would go great to have it configurable

As I am not sure about proper naming / place to put this -- feel free to throw it away or change, but the overall idea is:

```js
	return {
		exporter: {
			url: tracesEndpoint,
		},
		service: {
			name: serviceName,
			version: env.VERSION,
		},
                extraResourceAttributes: parseAttributes(env.OTEL_ATTRS)),
...
```

Also not sure if we should update readme as this is not an essential config part.