### PR TITLE
Allow disabling global fetch and cache instrumentation

### DIFF
--- a/.changeset/violet-bananas-attend.md
+++ b/.changeset/violet-bananas-attend.md
@@ -1,0 +1,5 @@
+---
+"@microlabs/otel-cf-workers": minor
+---
+
+Add option to disable auto-instrumentation of global fetch and cache API

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -76,8 +76,12 @@ function isSpanExporter(exporterConfig: ExporterConfig): exporterConfig is SpanE
 let initialised = false
 function init(config: ResolvedTraceConfig): void {
 	if (!initialised) {
-		instrumentGlobalCache()
-		instrumentGlobalFetch()
+		if (config.instrumentation.instrumentGlobalCache) {
+			instrumentGlobalCache()
+		}
+		if (config.instrumentation.instrumentGlobalFetch) {
+			instrumentGlobalFetch()
+		}
 		propagation.setGlobalPropagator(config.propagator)
 		const resource = createResource(config)
 
@@ -135,6 +139,10 @@ function parseConfig(supplied: TraceConfig): ResolvedTraceConfig {
 			service: supplied.service,
 			spanProcessors,
 			propagator: supplied.propagator || new W3CTraceContextPropagator(),
+			instrumentation: {
+				instrumentGlobalCache: supplied.instrumentation?.instrumentGlobalCache ?? true,
+				instrumentGlobalFetch: supplied.instrumentation?.instrumentGlobalFetch ?? true,
+			},
 		}
 	} else {
 		const exporter = isSpanExporter(supplied.exporter) ? supplied.exporter : new OTLPExporter(supplied.exporter)

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,11 @@ export interface SamplingConfig<HS extends HeadSamplerConf = HeadSamplerConf> {
 	tailSampler?: TailSampleFn
 }
 
+export interface InstrumentationOptions {
+	instrumentGlobalFetch?: boolean
+	instrumentGlobalCache?: boolean
+}
+
 interface TraceConfigBase {
 	service: ServiceConfig
 	handlers?: HandlerConfig
@@ -36,6 +41,7 @@ interface TraceConfigBase {
 	postProcessor?: PostProcessorFn
 	sampling?: SamplingConfig
 	propagator?: TextMapPropagator
+	instrumentation?: InstrumentationOptions
 }
 
 interface TraceConfigExporter extends TraceConfigBase {
@@ -59,6 +65,7 @@ export interface ResolvedTraceConfig extends TraceConfigBase {
 	sampling: Required<SamplingConfig<Sampler>>
 	spanProcessors: SpanProcessor[]
 	propagator: TextMapPropagator
+	instrumentation: InstrumentationOptions
 }
 
 export interface DOConstructorTrigger {


### PR DESCRIPTION
Fixes # [insert GH issue number(s)].

**What this PR solves / how to test:**

I was working on e2e tests for this package using the new vitest pool, and ran into a pile of errors when using fetch mocks and instrumented global fetch at the same time. To solve that (and possibly other issues), here's a config option to disable cache and fetch auto-instrumentation.