### PR TITLE
Add back service binding fetch instrumentation

### DIFF
--- a/.changeset/fluffy-wasps-laugh.md
+++ b/.changeset/fluffy-wasps-laugh.md
@@ -1,0 +1,5 @@
+---
+"@microlabs/otel-cf-workers": patch
+---
+
+Add back instrumentation of fetch in service bindings

--- a/src/instrumentation/env.ts
+++ b/src/instrumentation/env.ts
@@ -22,11 +22,6 @@ const isDurableObject = (item?: unknown): item is DurableObjectNamespace => {
 	return !isJSRPC(item) && !!(item as DurableObjectNamespace)?.idFromName
 }
 
-const isServiceBinding = (item?: unknown): item is Fetcher => {
-	const binding = item as Fetcher
-	return (!isJSRPC(item) && !!binding.connect) || !!binding.fetch || binding.queue || binding.scheduled
-}
-
 export const isVersionMetadata = (item?: unknown): item is WorkerVersionMetadata => {
 	return (
 		!isJSRPC(item) &&
@@ -47,16 +42,13 @@ const instrumentEnv = (env: Record<string, unknown>): Record<string, unknown> =>
 				return item
 			}
 			if (isJSRPC(item)) {
-				// TODO instrument JSRPC and maybe remove serviceBinding?
-				return item
+				return instrumentServiceBinding(item, String(prop))
 			} else if (isKVNamespace(item)) {
 				return instrumentKV(item, String(prop))
 			} else if (isQueue(item)) {
 				return instrumentQueueSender(item, String(prop))
 			} else if (isDurableObject(item)) {
 				return instrumentDOBinding(item, String(prop))
-			} else if (isServiceBinding(item)) {
-				return instrumentServiceBinding(item, String(prop))
 			} else if (isVersionMetadata(item)) {
 				// we do not need to log accesses to the metadata
 				return item


### PR DESCRIPTION
Ref #116 , #134 

**What this PR solves / how to test:**

When we added the fix for the JSRPC runtime change, we disabled their caller-side instrumentation completely. This PR adds back the same instrumentation that we had before. For anyone reading, we still need to figure out a non-breaking way to instrument RPC-style function calls without interfering with user code.