### PR TITLE
Rename service binding and client fetch spans

### DIFF
--- a/.changeset/pretty-coins-promise.md
+++ b/.changeset/pretty-coins-promise.md
@@ -2,4 +2,4 @@
 "@microlabs/otel-cf-workers": minor
 ---
 
-[Breaking] Rename client fetch and service binding spans
+[Breaking] Rename durable object fetch, client fetch and service binding spans

--- a/.changeset/pretty-coins-promise.md
+++ b/.changeset/pretty-coins-promise.md
@@ -1,0 +1,5 @@
+---
+"@microlabs/otel-cf-workers": minor
+---
+
+[Breaking] Rename client fetch and service binding spans

--- a/src/instrumentation/do.ts
+++ b/src/instrumentation/do.ts
@@ -24,7 +24,7 @@ function instrumentBindingStub(stub: DurableObjectStub, nsName: string): Durable
 			if (prop === 'fetch') {
 				const fetcher = Reflect.get(target, prop)
 				const attrs = {
-					name: `durable_object:${nsName}`,
+					name: `Durable Object ${nsName}`,
 					'do.namespace': nsName,
 					'do.id': target.id.toString(),
 					'do.id.name': target.id.name,

--- a/src/instrumentation/service.ts
+++ b/src/instrumentation/service.ts
@@ -7,7 +7,7 @@ export function instrumentServiceBinding(fetcher: Fetcher, envName: string): Fet
 			if (prop === 'fetch') {
 				const fetcher = Reflect.get(target, prop)
 				const attrs = {
-					name: `service_binding:${envName}`,
+					name: `Service Binding ${envName}`,
 				}
 				return instrumentClientFetch(fetcher, () => ({ includeTraceContext: true }), attrs)
 			} else {


### PR DESCRIPTION
Fixes # [insert GH issue number(s)].

**What this PR solves / how to test:**

Some spans were missed during #131, so here's a followup that renames Durable Object fetch, client fetch and service bindings.