### PR TITLE
Avoid calling bind on instances of RpcProperty

### DIFF
--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -45,11 +45,14 @@ export function unwrap<T extends object>(item: T): T {
 }
 
 export function passthroughGet(target: any, prop: string | symbol, thisArg?: any) {
-	const value = Reflect.get(unwrap(target), prop)
+	const unwrappedTarget = unwrap(target)
+	const value = Reflect.get(unwrappedTarget, prop)
 	if (typeof value === 'function') {
-		thisArg = thisArg || unwrap(target)
-		const bound = value.bind(thisArg)
-		return bound
+		if (value.constructor.name === 'RpcProperty') {
+			return (...args: unknown[]) => unwrappedTarget[prop](...args)
+		}
+		thisArg = thisArg || unwrappedTarget
+		return value.bind(thisArg)
 	} else {
 		return value
 	}


### PR DESCRIPTION
Fixes #139.

This PR inspects the unwrapped value, and if it's constructor is of `RpcProperty`, it handles binding by returning a different function that calls the RPC property as if it was bound.

I checked, and this sort of introspection is not unlike what Cloudflare do in their own Miniflare project:

https://github.com/cloudflare/workers-sdk/blob/d0754780c6d9a12984f1e4ed9b4f0952ba6b0888/packages/miniflare/src/workers/core/proxy.worker.ts#L223
