### PR TITLE
fix: make null not proxyable

### DIFF
--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -7,7 +7,7 @@ export function isWrapped<T>(item: T): item is Wrapped<T> {
 }
 
 export function isProxyable(item: any) {
-	return typeof item === 'object' || typeof item === 'function'
+	return (item !== null && typeof item === 'object') || typeof item === 'function'
 }
 
 export function wrap<T extends object>(item: T, handler: ProxyHandler<T>, autoPassthrough: boolean = true): T {


### PR DESCRIPTION
This crashes:

```ts
new Miniflare({
  ...,
  bindings: {
    SOMETHING: null
  }
});
```

because `null` crashes in `isVersionMetadata`.
So I fixed it by checking for `null` in `isProxyable`.