### PR TITLE
fix: null in isVersionMetadata

### DIFF
--- a/src/instrumentation/env.ts
+++ b/src/instrumentation/env.ts
@@ -25,8 +25,8 @@ const isDurableObject = (item?: unknown): item is DurableObjectNamespace => {
 export const isVersionMetadata = (item?: unknown): item is WorkerVersionMetadata => {
 	return (
 		!isJSRPC(item) &&
-		typeof (item as WorkerVersionMetadata).id === 'string' &&
-		typeof (item as WorkerVersionMetadata).tag === 'string'
+		typeof (item as WorkerVersionMetadata)?.id === 'string' &&
+		typeof (item as WorkerVersionMetadata)?.tag === 'string'
 	)
 }
 


### PR DESCRIPTION
I'm sorry, I didn't fully cover the issue from #147. There's another codepath that calls `isVersionMetadata`, and I fixed that function as well.