### PR TITLE
fix: traceFlags test in isHeadSampled function

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ Tail Sampling on the other hand is done at the end. Because we record every sing
 Example:
 
 ```typescript
-const tailSampler = (localTrace: LocalTrace): boolean => {
+const tailSampler = (traceInfo: LocalTrace): boolean => {
 	const localRootSpan = traceInfo.localRootSpan as unknown as ReadableSpan
-	return localRootSpan.spanContext().traceFlags === TraceFlags.SAMPLED
+	return (localRootSpan.spanContext().traceFlags & TraceFlags.SAMPLED) === TraceFlags.SAMPLED
 }
 ```
 

--- a/src/sampling.ts
+++ b/src/sampling.ts
@@ -17,7 +17,7 @@ export function multiTailSampler(samplers: TailSampleFn[]): TailSampleFn {
 
 export const isHeadSampled: TailSampleFn = (traceInfo) => {
 	const localRootSpan = traceInfo.localRootSpan as unknown as ReadableSpan
-	return localRootSpan.spanContext().traceFlags === TraceFlags.SAMPLED
+	return (localRootSpan.spanContext().traceFlags & TraceFlags.SAMPLED) === TraceFlags.SAMPLED
 }
 
 export const isRootErrorSpan: TailSampleFn = (traceInfo) => {


### PR DESCRIPTION
In the `isHeadSampled` function, the flag wasn't tested as a bit, but as a whole value
For now, since there is only one flag in TraceFlags, it works, but it won't in the future if a flag is added
