### PR TITLE
Fix issue where calling `fetch` in functions that weren't just instrumented threw an error

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ export function setConfig(config: ResolvedTraceConfig, ctx = context.active()) {
 	return ctx.setValue(configSymbol, config)
 }
 
-export function getActiveConfig(): ResolvedTraceConfig {
+export function getActiveConfig(): ResolvedTraceConfig | undefined {
 	const config = context.active().getValue(configSymbol) as ResolvedTraceConfig
-	return config
+	return config || undefined
 }

--- a/src/instrumentation/fetch.ts
+++ b/src/instrumentation/fetch.ts
@@ -112,7 +112,7 @@ export function getParentContextFromHeaders(headers: Headers): Context {
 }
 
 function getParentContextFromRequest(request: Request) {
-	const workerConfig = getActiveConfig()
+	const workerConfig = getActiveConfig() as ResolvedTraceConfig //Config should always be available
 	const acceptTraceContext =
 		typeof workerConfig.handlers.fetch.acceptTraceContext === 'function'
 			? workerConfig.handlers.fetch.acceptTraceContext(request)
@@ -208,6 +208,9 @@ export function instrumentClientFetch(
 			}
 
 			const workerConfig = getActiveConfig()
+			if (!workerConfig) {
+				return Reflect.apply(target, thisArg, [request])
+			}
 			const config = configFn(workerConfig)
 
 			const tracer = trace.getTracer('fetcher')

--- a/src/instrumentation/fetch.ts
+++ b/src/instrumentation/fetch.ts
@@ -112,7 +112,12 @@ export function getParentContextFromHeaders(headers: Headers): Context {
 }
 
 function getParentContextFromRequest(request: Request) {
-	const workerConfig = getActiveConfig() as ResolvedTraceConfig //Config should always be available
+	const workerConfig = getActiveConfig()
+
+	if (workerConfig === undefined) {
+		return api_context.active()
+	}
+
 	const acceptTraceContext =
 		typeof workerConfig.handlers.fetch.acceptTraceContext === 'function'
 			? workerConfig.handlers.fetch.acceptTraceContext(request)

--- a/src/spanprocessor.ts
+++ b/src/spanprocessor.ts
@@ -5,7 +5,7 @@ import { Action, State, stateMachine } from './vendor/ts-checked-fsm/StateMachin
 
 import { getActiveConfig } from './config.js'
 import { TailSampleFn } from './sampling.js'
-import { PostProcessorFn, ResolvedTraceConfig } from './types.js'
+import { PostProcessorFn } from './types.js'
 
 type CompletedTrace = {
 	traceId: string

--- a/src/spanprocessor.ts
+++ b/src/spanprocessor.ts
@@ -5,7 +5,7 @@ import { Action, State, stateMachine } from './vendor/ts-checked-fsm/StateMachin
 
 import { getActiveConfig } from './config.js'
 import { TailSampleFn } from './sampling.js'
-import { PostProcessorFn } from './types.js'
+import { PostProcessorFn, ResolvedTraceConfig } from './types.js'
 
 type CompletedTrace = {
 	traceId: string
@@ -131,7 +131,7 @@ export class BatchTraceSpanProcessor implements SpanProcessor {
 	}
 
 	private export(localRootSpanId: string) {
-		const { sampling, postProcessor } = getActiveConfig()
+		const { sampling, postProcessor } = getActiveConfig() as ResolvedTraceConfig //Config should always be available
 		const exportArgs = { exporter: this.exporter, tailSampler: sampling.tailSampler, postProcessor }
 		const newState = this.action(localRootSpanId, { actionName: 'startExport', args: exportArgs })
 		if (newState.stateName === 'exporting') {

--- a/src/spanprocessor.ts
+++ b/src/spanprocessor.ts
@@ -131,7 +131,10 @@ export class BatchTraceSpanProcessor implements SpanProcessor {
 	}
 
 	private export(localRootSpanId: string) {
-		const { sampling, postProcessor } = getActiveConfig() as ResolvedTraceConfig //Config should always be available
+		const config = getActiveConfig()
+		if (!config) throw new Error('Config is undefined. This is a bug in the instrumentation logic')
+
+		const { sampling, postProcessor } = config
 		const exportArgs = { exporter: this.exporter, tailSampler: sampling.tailSampler, postProcessor }
 		const newState = this.action(localRootSpanId, { actionName: 'startExport', args: exportArgs })
 		if (newState.stateName === 'exporting') {

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -45,7 +45,9 @@ export class WorkerTracer implements Tracer {
 		const spanKind = options.kind || SpanKind.INTERNAL
 		const sanitisedAttrs = sanitizeAttributes(options.attributes)
 
-		const config = getActiveConfig() as ResolvedTraceConfig //Config should always be available
+		const config = getActiveConfig()
+		if (!config) throw new Error('Config is undefined. This is a bug in the instrumentation logic')
+
 		const sampler = config.sampling.headSampler
 		const samplingDecision = sampler.shouldSample(context, traceId, name, spanKind, sanitisedAttrs, [])
 		const { decision, traceState, attributes: attrs } = samplingDecision

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -14,7 +14,6 @@ import { SpanProcessor, RandomIdGenerator, ReadableSpan, SamplingDecision } from
 
 import { SpanImpl } from './span.js'
 import { getActiveConfig } from './config.js'
-import { ResolvedTraceConfig } from './types.js'
 
 export class WorkerTracer implements Tracer {
 	private readonly _spanProcessors: SpanProcessor[]

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -14,6 +14,7 @@ import { SpanProcessor, RandomIdGenerator, ReadableSpan, SamplingDecision } from
 
 import { SpanImpl } from './span.js'
 import { getActiveConfig } from './config.js'
+import { ResolvedTraceConfig } from './types.js'
 
 export class WorkerTracer implements Tracer {
 	private readonly _spanProcessors: SpanProcessor[]
@@ -44,7 +45,8 @@ export class WorkerTracer implements Tracer {
 		const spanKind = options.kind || SpanKind.INTERNAL
 		const sanitisedAttrs = sanitizeAttributes(options.attributes)
 
-		const sampler = getActiveConfig().sampling.headSampler
+		const config = getActiveConfig() as ResolvedTraceConfig //Config should always be available
+		const sampler = config.sampling.headSampler
 		const samplingDecision = sampler.shouldSample(context, traceId, name, spanKind, sanitisedAttrs, [])
 		const { decision, traceState, attributes: attrs } = samplingDecision
 		const attributes = Object.assign({}, sanitisedAttrs, attrs)


### PR DESCRIPTION
**What this PR solves / how to test:**

Functions on objects where some functions were instrumented, but not others (for example the Durable Object hibernateable Websocket API), would throw an error when calling `fetch`.

This shouldn't happen anymore :)

Thanks @benstechlab for the help in getting this PR out.