### PR TITLE
 fix: otlp json encoding

### DIFF
--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -43,7 +43,10 @@ export class OTLPExporter implements SpanExporter {
 	}
 
 	send(items: any[], onSuccess: () => void, onError: (error: OTLPExporterError) => void): void {
-		const exportMessage = createExportTraceServiceRequest(items)
+		const exportMessage = createExportTraceServiceRequest(items, {
+			useHex: true,
+			useLongBits: false,
+		})
 		const body = JSON.stringify(exportMessage)
 		const params: RequestInit = {
 			method: 'POST',


### PR DESCRIPTION
Regression introduced in commit https://github.com/evanderkoogh/otel-cf-workers/commit/bd0a46a69da163ded5a6412b5bc839db159dd8f9 after api change in https://github.com/open-telemetry/opentelemetry-js/pull/4220

Fixes # [insert GH issue number(s)].

**What this PR solves / how to test:**

Update of opentelemetry api replaced boolean parameter useHex with options object. Without this object, it defaults to parameters `{ useHex: false, useLongBits: true }` which cannot be ingested by otel collector.

Tested manually by comparing data sent to local instance.