### PR TITLE
build build-dependent versions.json before build builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"build-esm": "tsc",
 		"build-cjs": "tsc -p tsconfig-cjs.json",
 		"fix-dist": "echo '{\"type\": \"module\"}' > dist/esm/package.json && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
-		"build": "run-s -l build-esm build-cjs fix-dist",
+		"build": "run-s -l cs-version build-esm build-cjs fix-dist",
 		"cs-version": "changeset version && pnpm version --json > versions.json",
 		"cs-publish": "changeset publish",
 		"release": "run-s -l clean cs-version build cs-publish",


### PR DESCRIPTION
add cs-version to build script b/c github action builds before it releases (currently version file is only generated in release step

Fixes #164 

**What this PR solves / how to test:**
* fix failed build

to test:
- `npm run clean`
- `npm run build`
- ✅ 