### PR TITLE
feat: add support for email triggers

### DIFF
--- a/.changeset/thirty-ties-float.md
+++ b/.changeset/thirty-ties-float.md
@@ -1,0 +1,15 @@
+---
+'@microlabs/otel-cf-workers': minor
+---
+
+add support for `email` handlers
+
+Example usage:
+
+```ts
+export default {
+  async email(message, env, ctx) {
+    // this is running in a trace!
+  },
+};
+```

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ One of the advantages of using Open Telemetry is that it makes it easier to do d
 
 Triggers:
 
-- [ ] Email (`handler.email`)
+- [x] Email (`handler.email`)
 - [x] HTTP (`handler.fetch`)
 - [x] Queue (`handler.queue`)
 - [x] Cron (`handler.scheduled`)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"scripts": {
 		"clean": "rimraf ./dist versions.json",
 		"format": "prettier --ignore-unknown --write .",
-		"build:src": "tsup src/index.ts --format cjs,esm --dts --clean --sourcemap",
+		"build:src": "tsup",
 		"build:versions": "pnpm version --json > versions.json",
 		"build": "run-s -l build:versions build:src",
 		"cs-version": "changeset version",

--- a/src/instrumentation/email.ts
+++ b/src/instrumentation/email.ts
@@ -1,0 +1,76 @@
+import { setConfig, type Initialiser } from '../config'
+import { wrap } from '../wrap'
+import { exportSpans, proxyExecutionContext } from './common'
+import { context as api_context, Exception, SpanKind, type SpanOptions, trace } from '@opentelemetry/api'
+import { instrumentEnv } from './env'
+import { versionAttributes } from './version'
+import {
+	ATTR_FAAS_TRIGGER,
+	ATTR_MESSAGING_DESTINATION_NAME,
+	ATTR_RPC_MESSAGE_ID,
+} from '@opentelemetry/semantic-conventions/incubating'
+
+type EmailHandler = EmailExportedHandler
+export type EmailHandlerArgs = Parameters<EmailHandler>
+
+export function createEmailHandler(emailFn: EmailHandler, initialiser: Initialiser): EmailHandler {
+	const emailHandler: ProxyHandler<EmailHandler> = {
+		async apply(target, _thisArg, argArray: Parameters<EmailHandler>): Promise<void> {
+			const [message, orig_env, orig_ctx] = argArray
+			const config = initialiser(orig_env as Record<string, unknown>, message)
+			const env = instrumentEnv(orig_env as Record<string, unknown>)
+			const { ctx, tracker } = proxyExecutionContext(orig_ctx)
+			const context = setConfig(config)
+
+			try {
+				const args: EmailHandlerArgs = [message, env, ctx]
+				return await api_context.with(context, executeEmailHandler, undefined, target, args)
+			} catch (error) {
+				throw error
+			} finally {
+				orig_ctx.waitUntil(exportSpans(tracker))
+			}
+		},
+	}
+	return wrap(emailFn, emailHandler)
+}
+
+/**
+ * Converts the message headers into a record ready to be injected
+ * as OpenTelemetry attributes
+ *
+ * @example
+ * ```ts
+ * const headers = new Headers({ "Subject": "Hello!", From: "hello@example.com" })
+ * headerAttributes({ headers })
+ * // => {"email.header.Subject": "Hello!", "email.header.From": "hello@example.com"}
+ * ```
+ */
+function headerAttributes(message: { headers: Headers }): Record<string, unknown> {
+	return Object.fromEntries([...message.headers].map(([key, value]) => [`email.header.${key}`, value] as const))
+}
+
+async function executeEmailHandler(emailFn: EmailHandler, [message, env, ctx]: EmailHandlerArgs): Promise<void> {
+	const tracer = trace.getTracer('emailHandler')
+	const options = {
+		attributes: {
+			[ATTR_FAAS_TRIGGER]: 'other',
+			[ATTR_RPC_MESSAGE_ID]: message.headers.get('Message-Id') ?? undefined,
+			[ATTR_MESSAGING_DESTINATION_NAME]: message.to,
+		},
+		kind: SpanKind.CONSUMER,
+	} satisfies SpanOptions
+	Object.assign(options.attributes!, headerAttributes(message), versionAttributes(env))
+	const promise = tracer.startActiveSpan(`emailHandler ${message.to}`, options, async (span) => {
+		try {
+			const result = await emailFn(message, env, ctx)
+			span.end()
+			return result
+		} catch (error) {
+			span.recordException(error as Exception)
+			span.end()
+			throw error
+		}
+	})
+	return promise
+}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -13,7 +13,6 @@ import { createScheduledHandler } from './instrumentation/scheduled.js'
 //@ts-ignore
 import * as versions from '../versions.json'
 import { createEmailHandler } from './instrumentation/email.js'
-import { EmailMessage } from 'cloudflare:email'
 
 type FetchHandler = ExportedHandlerFetchHandler<unknown, unknown>
 type ScheduledHandler = ExportedHandlerScheduledHandler<unknown>
@@ -33,10 +32,6 @@ export function isMessageBatch(trigger: Trigger): trigger is MessageBatch {
 
 export function isAlarm(trigger: Trigger): trigger is 'do-alarm' {
 	return trigger === 'do-alarm'
-}
-
-export function isEmailMessage(trigger: Trigger): trigger is ForwardableEmailMessage {
-	return !!(trigger instanceof EmailMessage && trigger.headers && trigger.forward)
 }
 
 const createResource = (config: ResolvedTraceConfig): Resource => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,4 +73,10 @@ export interface DOConstructorTrigger {
 	name?: string
 }
 
-export type Trigger = Request | MessageBatch | ScheduledController | DOConstructorTrigger | 'do-alarm'
+export type Trigger =
+	| Request
+	| MessageBatch
+	| ScheduledController
+	| DOConstructorTrigger
+	| 'do-alarm'
+	| ForwardableEmailMessage

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: true,
+})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
 	dts: true,
 	clean: true,
 	sourcemap: true,
+	external: ['cloudflare:email'],
 })

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,5 +6,4 @@ export default defineConfig({
 	dts: true,
 	clean: true,
 	sourcemap: true,
-	external: ['cloudflare:email'],
 })


### PR DESCRIPTION
**What this PR solves / how to test:**

Ain't much but it's honest work ;D
This PR adds support for `email` handlers in Cloudflare Workers:

```ts
export default {
  async email(message, env, ctx) {
    // this is running in a trace!
  },
};
```
This PR _does not_ instrument `email.reply` etc. It's out of scope of this PR. It's only for creating a span/trace for receiving the emails.
