### PR TITLE
fix: Adding try-finally in instrumentClientFetch to ensure spans are …

### DIFF
--- a/src/instrumentation/fetch.ts
+++ b/src/instrumentation/fetch.ts
@@ -237,7 +237,12 @@ export function instrumentClientFetch(
 					const response = await Reflect.apply(target, thisArg, [request])
 					span.setAttributes(gatherResponseAttributes(response))
 					return response
-				} finally {
+				} catch (error) {
+					span.recordException(error as Exception)
+					span.setStatus({ code: SpanStatusCode.ERROR })
+					throw error
+				}
+				finally {
 					span.end()
 				}
 			})


### PR DESCRIPTION
…closed on non HTTP errors such as Network connection lost.

Fixes # [insert GH issue number(s)].

**What this PR solves / how to test:**
Errors in fetch that aren't handled by Cloudflare such as intermittent connection failures to other workers or durable objects currently result in the span remaining open. This small fix ensures that the spans are closed on any such unhandled errors.
