### PR TITLE
Update README.md to point out D1 is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Bindings:
 - [x] Queue
 - [x] Durable Objects
 - [ ] R2
-- [ ] D1
+- [x] D1
 - [x] Service Bindings
 - [x] Analytics Engine
 - [ ] Browser Rendering


### PR DESCRIPTION
Fixes # [insert GH issue number(s)].

**What this PR solves / how to test:**

I noticed that D1 was already supported but the READme didn't reflect that, so I thought I'd just update it quick.

https://github.com/evanderkoogh/otel-cf-workers/blob/main/src/instrumentation/env.ts#L62 is where the handling for it starts I think
