### PR TITLE
Support OTel scope configuration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -70,6 +70,7 @@ export function parseConfig(supplied: TraceConfig): ResolvedTraceConfig {
 				instrumentGlobalCache: supplied.instrumentation?.instrumentGlobalCache ?? true,
 				instrumentGlobalFetch: supplied.instrumentation?.instrumentGlobalFetch ?? true,
 			},
+			scope: supplied.scope || { name: '@microlabs/otel-cf-workers' },
 		}
 	} else {
 		const exporter = isSpanExporter(supplied.exporter) ? supplied.exporter : new OTLPExporter(supplied.exporter)

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -5,6 +5,7 @@ import { Resource } from '@opentelemetry/resources'
 
 import { AsyncLocalStorageContextManager } from './context.js'
 import { WorkerTracer } from './tracer.js'
+import { InstrumentationScope } from '@opentelemetry/core'
 
 /**
  * Register this TracerProvider for use with the OpenTelemetry API.
@@ -17,16 +18,18 @@ export class WorkerTracerProvider implements TracerProvider {
 	private spanProcessors: SpanProcessor[]
 	private resource: Resource
 	private tracers: Record<string, Tracer> = {}
+	private scope: InstrumentationScope
 
-	constructor(spanProcessors: SpanProcessor[], resource: Resource) {
+	constructor(spanProcessors: SpanProcessor[], resource: Resource, scope: InstrumentationScope) {
 		this.spanProcessors = spanProcessors
 		this.resource = resource
+		this.scope = scope
 	}
 
 	getTracer(name: string, version?: string, options?: TracerOptions): Tracer {
 		const key = `${name}@${version || ''}:${options?.schemaUrl || ''}`
 		if (!this.tracers[key]) {
-			this.tracers[key] = new WorkerTracer(this.spanProcessors, this.resource)
+			this.tracers[key] = new WorkerTracer(this.spanProcessors, this.resource, this.scope)
 		}
 		return this.tracers[key]!
 	}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -66,7 +66,7 @@ function init(config: ResolvedTraceConfig): void {
 		propagation.setGlobalPropagator(config.propagator)
 		const resource = createResource(config)
 
-		const provider = new WorkerTracerProvider(config.spanProcessors, resource)
+		const provider = new WorkerTracerProvider(config.spanProcessors, resource, config.scope)
 		provider.register()
 		initialised = true
 	}

--- a/src/span.ts
+++ b/src/span.ts
@@ -14,6 +14,7 @@ import {
 import {
 	hrTimeDuration,
 	InstrumentationLibrary,
+	InstrumentationScope,
 	isAttributeKey,
 	isAttributeValue,
 	isTimeInput,
@@ -30,6 +31,7 @@ interface SpanInit {
 	name: string
 	onEnd: OnSpanEnd
 	resource: IResource
+	scope: InstrumentationScope
 	spanContext: SpanContext
 	links?: Link[]
 	parentSpanId?: string
@@ -94,7 +96,10 @@ export class SpanImpl implements Span, ReadableSpan {
 	readonly events: TimedEvent[] = []
 	readonly links: Link[]
 	readonly resource: IResource
-	instrumentationLibrary: InstrumentationLibrary = { name: '@microlabs/otel-cf-workers' }
+	readonly instrumentationScope: InstrumentationScope
+	// TODO: remove this when upgrading to the latest packages.
+	// ReadableSpan still asks for it, even though it's deprecated.
+	readonly instrumentationLibrary: InstrumentationLibrary
 	private _ended: boolean = false
 	private _droppedAttributesCount: number = 0
 	private _droppedEventsCount: number = 0
@@ -109,6 +114,10 @@ export class SpanImpl implements Span, ReadableSpan {
 		this.startTime = getHrTime(init.startTime)
 		this.links = init.links || []
 		this.resource = init.resource
+
+		this.instrumentationScope = init.scope
+		// instrumentationLibrary is deprecated in favor of instrumentationScope, it has the same shape
+		this.instrumentationLibrary = init.scope
 		this.onEnd = init.onEnd
 	}
 

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -9,7 +9,7 @@ import {
 	context as api_context,
 	trace,
 } from '@opentelemetry/api'
-import { sanitizeAttributes } from '@opentelemetry/core'
+import { InstrumentationScope, sanitizeAttributes } from '@opentelemetry/core'
 import { Resource } from '@opentelemetry/resources'
 import { SpanProcessor, RandomIdGenerator, ReadableSpan, SamplingDecision } from '@opentelemetry/sdk-trace-base'
 
@@ -21,10 +21,12 @@ let withNextSpanAttributes: Attributes
 export class WorkerTracer implements Tracer {
 	private readonly _spanProcessors: SpanProcessor[]
 	private readonly resource: Resource
+	private readonly scope: InstrumentationScope
 	private readonly idGenerator: RandomIdGenerator = new RandomIdGenerator()
-	constructor(spanProcessors: SpanProcessor[], resource: Resource) {
+	constructor(spanProcessors: SpanProcessor[], resource: Resource, scope: InstrumentationScope) {
 		this._spanProcessors = spanProcessors
 		this.resource = resource
+		this.scope = scope
 	}
 
 	get spanProcessors() {
@@ -71,6 +73,7 @@ export class WorkerTracer implements Tracer {
 				})
 			},
 			resource: this.resource,
+			scope: this.scope,
 			spanContext,
 			parentSpanId,
 			spanKind,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { ReadableSpan, Sampler, SpanExporter, SpanProcessor } from '@opentelemet
 import { OTLPExporterConfig } from './exporter.js'
 import { FetchHandlerConfig, FetcherConfig } from './instrumentation/fetch.js'
 import { TailSampleFn } from './sampling.js'
+import { InstrumentationScope } from '@opentelemetry/core'
 
 export type PostProcessorFn = (spans: ReadableSpan[]) => ReadableSpan[]
 
@@ -17,6 +18,8 @@ export interface ServiceConfig {
 	namespace?: string
 	version?: string
 }
+
+export interface ScopeConfig extends InstrumentationScope {}
 
 export interface ParentRatioSamplingConfig {
 	acceptRemote?: boolean
@@ -36,6 +39,7 @@ export interface InstrumentationOptions {
 
 interface TraceConfigBase {
 	service: ServiceConfig
+	scope?: ScopeConfig
 	handlers?: HandlerConfig
 	fetch?: FetcherConfig
 	postProcessor?: PostProcessorFn
@@ -66,6 +70,7 @@ export interface ResolvedTraceConfig extends TraceConfigBase {
 	spanProcessors: SpanProcessor[]
 	propagator: TextMapPropagator
 	instrumentation: InstrumentationOptions
+	scope: InstrumentationScope
 }
 
 export interface DOConstructorTrigger {


### PR DESCRIPTION
This change supports configuration of the OTel scope used. The `instrumentationLibrary` field can be dropped after the upgrade to the latest OTel libraries. 