### PR TITLE
Support id generator configuration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ import {
 	Trigger,
 } from './types.js'
 import { W3CTraceContextPropagator } from '@opentelemetry/core'
-import { AlwaysOnSampler, ReadableSpan, Sampler, SpanExporter } from '@opentelemetry/sdk-trace-base'
+import { AlwaysOnSampler, RandomIdGenerator, ReadableSpan, Sampler, SpanExporter } from '@opentelemetry/sdk-trace-base'
 
 import { OTLPExporter } from './exporter.js'
 import { multiTailSampler, isHeadSampled, isRootErrorSpan, createSampler } from './sampling.js'
@@ -70,6 +70,7 @@ export function parseConfig(supplied: TraceConfig): ResolvedTraceConfig {
 				instrumentGlobalCache: supplied.instrumentation?.instrumentGlobalCache ?? true,
 				instrumentGlobalFetch: supplied.instrumentation?.instrumentGlobalFetch ?? true,
 			},
+			idGenerator: supplied.idGenerator || new RandomIdGenerator(),
 		}
 	} else {
 		const exporter = isSpanExporter(supplied.exporter) ? supplied.exporter : new OTLPExporter(supplied.exporter)

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,7 +1,7 @@
 import { context, trace, Tracer, TracerOptions, TracerProvider } from '@opentelemetry/api'
 
-import { SpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { Resource } from '@opentelemetry/resources'
+import { IdGenerator, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 
 import { AsyncLocalStorageContextManager } from './context.js'
 import { WorkerTracer } from './tracer.js'
@@ -17,16 +17,18 @@ export class WorkerTracerProvider implements TracerProvider {
 	private spanProcessors: SpanProcessor[]
 	private resource: Resource
 	private tracers: Record<string, Tracer> = {}
+	private idGenerator: IdGenerator
 
-	constructor(spanProcessors: SpanProcessor[], resource: Resource) {
+	constructor(spanProcessors: SpanProcessor[], resource: Resource, idGenerator: IdGenerator) {
 		this.spanProcessors = spanProcessors
 		this.resource = resource
+		this.idGenerator = idGenerator
 	}
 
 	getTracer(name: string, version?: string, options?: TracerOptions): Tracer {
 		const key = `${name}@${version || ''}:${options?.schemaUrl || ''}`
 		if (!this.tracers[key]) {
-			this.tracers[key] = new WorkerTracer(this.spanProcessors, this.resource)
+			this.tracers[key] = new WorkerTracer(this.spanProcessors, this.resource, this.idGenerator)
 		}
 		return this.tracers[key]!
 	}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -66,7 +66,7 @@ function init(config: ResolvedTraceConfig): void {
 		propagation.setGlobalPropagator(config.propagator)
 		const resource = createResource(config)
 
-		const provider = new WorkerTracerProvider(config.spanProcessors, resource)
+		const provider = new WorkerTracerProvider(config.spanProcessors, resource, config.idGenerator)
 		provider.register()
 		initialised = true
 	}

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -1,30 +1,31 @@
 import {
 	Attributes,
-	Tracer,
-	TraceFlags,
+	Context,
 	Span,
 	SpanKind,
 	SpanOptions,
-	Context,
+	TraceFlags,
+	Tracer,
 	context as api_context,
 	trace,
 } from '@opentelemetry/api'
 import { sanitizeAttributes } from '@opentelemetry/core'
 import { Resource } from '@opentelemetry/resources'
-import { SpanProcessor, RandomIdGenerator, ReadableSpan, SamplingDecision } from '@opentelemetry/sdk-trace-base'
+import { IdGenerator, ReadableSpan, SamplingDecision, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 
-import { SpanImpl } from './span.js'
 import { getActiveConfig } from './config.js'
+import { SpanImpl } from './span.js'
 
 let withNextSpanAttributes: Attributes
 
 export class WorkerTracer implements Tracer {
 	private readonly _spanProcessors: SpanProcessor[]
 	private readonly resource: Resource
-	private readonly idGenerator: RandomIdGenerator = new RandomIdGenerator()
-	constructor(spanProcessors: SpanProcessor[], resource: Resource) {
+	private readonly idGenerator: IdGenerator
+	constructor(spanProcessors: SpanProcessor[], resource: Resource, idGenerator: IdGenerator) {
 		this._spanProcessors = spanProcessors
 		this.resource = resource
+		this.idGenerator = idGenerator
 	}
 
 	get spanProcessors() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { TextMapPropagator } from '@opentelemetry/api'
-import { ReadableSpan, Sampler, SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { IdGenerator, ReadableSpan, Sampler, SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { OTLPExporterConfig } from './exporter.js'
 import { FetchHandlerConfig, FetcherConfig } from './instrumentation/fetch.js'
 import { TailSampleFn } from './sampling.js'
@@ -42,6 +42,7 @@ interface TraceConfigBase {
 	sampling?: SamplingConfig
 	propagator?: TextMapPropagator
 	instrumentation?: InstrumentationOptions
+	idGenerator?: IdGenerator
 }
 
 interface TraceConfigExporter extends TraceConfigBase {
@@ -66,6 +67,7 @@ export interface ResolvedTraceConfig extends TraceConfigBase {
 	spanProcessors: SpanProcessor[]
 	propagator: TextMapPropagator
 	instrumentation: InstrumentationOptions
+	idGenerator: IdGenerator
 }
 
 export interface DOConstructorTrigger {


### PR DESCRIPTION
This change allows the configuration of the span id/trace id generators. We're using ULIDs: 

https://github.com/pydantic/logfire/pull/783. 

Discussion: 
https://github.com/open-telemetry/opentelemetry-specification/issues/1947#issuecomment-2565060818

This PR will mechanically clash with #194, because it's touching the same lines. I'm happy to help with the conflict resolution, it's a fairly simple one. 