### PR TITLE
Support customization of fetch spans

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,7 @@ export function parseConfig(supplied: TraceConfig): ResolvedTraceConfig {
 			handlers: {
 				fetch: {
 					acceptTraceContext: supplied.handlers?.fetch?.acceptTraceContext ?? true,
+					postProcess: supplied.handlers?.fetch?.postProcess,
 				},
 			},
 			postProcessor: supplied.postProcessor || ((spans: ReadableSpan[]) => spans),


### PR DESCRIPTION
This change allows capturing more details about the fetch instrumentation spans. 

For example, this config would capture request/response headers and change the message of the span: 

```ts
		handlers: {
			fetch: {
				postProcess: (span, { request, response, readable }) => {
					span.updateName(`fetchHandler ${request.method.toUpperCase()} ${readable.attributes['url.path']}`);
					for (const [key, value] of request.headers.entries()) {
						span.setAttribute(`http.request.header.${key}`, value);
					}
					for (const [key, value] of response.headers.entries()) {
						span.setAttribute(`http.response.header.${key}`, value);
					}
				},
			},
		},

```