### PR TITLE
Get post processor execution back

### DIFF
--- a/src/spanprocessor.ts
+++ b/src/spanprocessor.ts
@@ -72,6 +72,12 @@ class TraceState {
 	}
 
 	private async exportSpans(spans: ReadableSpan[]): Promise<void> {
+		const config = getActiveConfig()
+		if (!config) {
+			console.log('Could not find config for exporting, skipping export')
+			return
+		}
+		config.postProcessor(spans)
 		await scheduler.wait(1)
 		const promise = new Promise<void>((resolve, reject) => {
 			this.exporter.export(spans, (result) => {


### PR DESCRIPTION
Fixes #207 

Just reverts back some old code which was there before.
Ideally would be great to write some unit tests to ensure the functionality which would be useful for the future.
Tested locally with Miniflare emulator.