### PR TITLE
Instrument HTTP request end-to-end

### DIFF
--- a/src/instrumentation/fetch.ts
+++ b/src/instrumentation/fetch.ts
@@ -196,13 +196,26 @@ export function instrumentClientFetch(
 					if (request.cf) span.setAttributes(gatherOutgoingCfAttributes(request.cf))
 					const response = await Reflect.apply(target, thisArg, [request])
 					span.setAttributes(gatherResponseAttributes(response))
-					return response
+
+					if (!response.body) {
+						span.end()
+						return response
+					}
+
+					const transformer = new TransformStream({
+						transform(chunk, controller) {
+							controller.enqueue(chunk)
+						},
+						flush() {
+							span.end()
+						},
+					})
+					return new Response(response.body.pipeThrough(transformer), response)
 				} catch (error: unknown) {
 					span.recordException(error as Exception)
 					span.setStatus({ code: SpanStatusCode.ERROR })
-					throw error
-				} finally {
 					span.end()
+					throw error
 				}
 			})
 			return promise


### PR DESCRIPTION
**What this PR solves / how to test:**

Currently the span associated with a fetch() HTTP request is closed once the headers have been received and the promise resolves with a `Response` object. However this does not account for the time taken to stream the response body back to the client resulting in an inconsistent span.

This commit extends the current span to include the transfer of the HTTP response body rather than ending it when the headers complete. This provides a fuller, more accurate picture of the HTTP request.

This is implemented using a `TransformStream` on the HTTP response body that acts as a pass-through and only calling `span.end()` once the stream has completed.

