### PR TITLE
fix: wrap() bind trap honors thisArg (fixes Illegal invocation with SDKs that pre-bind fetch)

### DIFF
--- a/.changeset/fix-bind-trap-honors-thisarg.md
+++ b/.changeset/fix-bind-trap-honors-thisarg.md
@@ -1,0 +1,14 @@
+---
+'@microlabs/otel-cf-workers': patch
+---
+
+fix: `wrap()` bind trap honors Function.prototype.bind semantics
+
+The proxy `.bind` trap previously returned `() => receiver`, silently
+dropping any passed thisArg. SDKs that defensively bind `globalThis.fetch`
+to `globalThis` (e.g. WorkOS, Stripe) to satisfy Cloudflare's this-strict
+native fetch ended up with their bind discarded. Later calls like
+`this._fetchFn(...)` forwarded the caller's `this` to native fetch and
+threw `TypeError: Illegal invocation`. The trap now returns a function
+that forwards to the proxy's apply trap with the requested thisArg and
+bound arguments, matching the language-level contract of `.bind`.

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -22,7 +22,16 @@ export function wrap<T extends object>(item: T, handler: ProxyHandler<T>, autoPa
 			if (handler.get) {
 				return handler.get(target, prop, receiver)
 			} else if (prop === 'bind') {
-				return () => receiver
+				// Honor Function.prototype.bind semantics. SDKs bind fetch to
+				// globalThis (e.g. WorkOS, Stripe) to satisfy Cloudflare's
+				// this-strict native fetch. Returning `() => receiver` silently
+				// drops the thisArg, so later invocations with `this.fn(...)`
+				// forward the caller's `this` to native fetch and it throws
+				// "Illegal invocation". Return a proper bound call that forwards
+				// to the proxy's apply trap with the requested thisArg.
+				return (thisArg: unknown, ...boundArgs: unknown[]) =>
+					(...callArgs: unknown[]) =>
+						Reflect.apply(receiver as (...args: unknown[]) => unknown, thisArg, [...boundArgs, ...callArgs])
 			} else if (autoPassthrough) {
 				return passthroughGet(target, prop)
 			}

--- a/test/wrap.test.ts
+++ b/test/wrap.test.ts
@@ -36,4 +36,38 @@ describe('wrap', () => {
 		const wrapped = wrap(unwrapped, {})
 		expect(unwrap(wrapped)).toBe(unwrapped)
 	})
+
+	// Regression: SDKs (e.g. WorkOS, Stripe) bind `globalThis.fetch` to `globalThis`
+	// at construction to satisfy Cloudflare's this-strict native fetch. Previously
+	// the `.bind` trap returned `() => receiver`, silently dropping the thisArg, so
+	// subsequent calls forwarded the caller's `this` to native fetch and threw
+	// "Illegal invocation". The trap must honor Function.prototype.bind semantics.
+	it('.bind honors thisArg and bound args', () => {
+		const target = function (this: unknown, ...args: unknown[]) {
+			return { receivedThis: this, receivedArgs: args }
+		}
+		const callLog: Array<{ thisArg: unknown; args: unknown[] }> = []
+		const wrapped = wrap(target, {
+			apply(inner, thisArg, argArray) {
+				callLog.push({ thisArg, args: argArray })
+				return Reflect.apply(inner as (...a: unknown[]) => unknown, thisArg, argArray)
+			},
+		}) as (...args: unknown[]) => { receivedThis: unknown; receivedArgs: unknown[] }
+
+		const pinnedThis = { marker: 'globalThis-substitute' }
+		const bound = (wrapped as unknown as { bind: (t: unknown, ...a: unknown[]) => typeof wrapped }).bind(
+			pinnedThis,
+			'bound-arg',
+		)
+
+		// Invoke like `obj.method(...)` so JS would normally set `this = obj` — but
+		// the bind should pin `this` to `pinnedThis` and prepend the bound arg.
+		const caller = { bound }
+		const result = caller.bound('call-arg')
+
+		expect(result.receivedThis).toBe(pinnedThis)
+		expect(result.receivedArgs).toEqual(['bound-arg', 'call-arg'])
+		expect(callLog).toHaveLength(1)
+		expect(callLog[0]?.thisArg).toBe(pinnedThis)
+	})
 })


### PR DESCRIPTION
## Problem

Any SDK that defensively calls `fetch.bind(globalThis)` inside a Cloudflare Worker throws `TypeError: Illegal invocation` at request time when this library is installed. WorkOS (`@workos-inc/node`), Stripe, and other SDKs do this to satisfy Cloudflare's this-strict native fetch — they pin `this = globalThis` at construction, then later call `this._fetchFn(...)` from a class method where JS would otherwise set `this = instance`.

The root cause is in the `.bind` trap in `src/wrap.ts:24-25`:

```ts
} else if (prop === 'bind') {
  return () => receiver
}
```

This returns a nullary arrow that ignores `.bind`'s arguments. The SDK's intent to pin `this = globalThis` is silently dropped — `this._fetchFn` ends up holding the proxy itself, not a bound version. When the SDK later calls `this._fetchFn(url, opts)`, the proxy's `apply` trap fires with `thisArg = FetchHttpClient` (or whatever class owns the method), and `Reflect.apply(nativeFetch, FetchHttpClient, [request])` throws `Illegal invocation` because native `fetch` requires `this === globalThis`.

## Fix

Honor `Function.prototype.bind` semantics. The trap now returns a function that, when invoked, forwards to the proxy's own `apply` trap with the requested `thisArg` and bound arguments:

```ts
} else if (prop === 'bind') {
  return (thisArg, ...boundArgs) =>
    (...callArgs) =>
      Reflect.apply(receiver, thisArg, [...boundArgs, ...callArgs])
}
```

Tracing still works — `Reflect.apply(receiver, thisArg, ...)` hits the proxy's `apply` handler, which unwraps and fires the span as before — and `thisArg` now propagates correctly through to native fetch.

## Reproduction

Pre-fix vs post-fix on the same Node harness:

```js
// Simulates native fetch's this-strict contract
function strictFn(arg) {
  if (this !== globalThis) throw new TypeError('Illegal invocation')
  return { called: true, arg }
}

class Client {
  constructor(fn) { this._fn = fn.bind(globalThis) }
  run(arg) { return this._fn(arg) }
}

const wrapped = wrap(strictFn, {
  apply: (inner, thisArg, args) => Reflect.apply(inner, thisArg, args),
})
new Client(wrapped).run('hello')
```

- Before: `TypeError: Illegal invocation`
- After: `{ called: true, arg: 'hello' }`

## Scope

- `src/wrap.ts`: trap change only — no behavior change for handlers that supply their own `.get`.
- `test/wrap.test.ts`: regression test covering bind's thisArg + bound-arg forwarding.
- Changeset added (`patch`).
- Observed in the wild running `@workos-inc/node@8.13.0` under this library in a Cloudflare Worker; any SDK doing `fetch.bind(globalThis)` defensively is affected the same way.