### PR TITLE
fix: add package repository and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,13 @@
 		"dist"
 	],
 	"homepage": "https://github.com/evanderkoogh/otel-cf-workers#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/evanderkoogh/otel-cf-workers.git"
+	},
+	"bugs": {
+		"url": "https://github.com/evanderkoogh/otel-cf-workers/issues"
+	},
 	"dependencies": {
 		"@opentelemetry/core": "^2.0.0",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.200.0",


### PR DESCRIPTION
## Summary
- add npm `repository` metadata for `@microlabs/otel-cf-workers`
- add npm `bugs.url` metadata pointing to this repository's issue tracker
- preserve the existing package name, version, homepage, license, runtime exports, dependencies, and source code

## Validation
- `node` package metadata assertion
- `pnpm exec prettier package.json --check`
- `npm pack --dry-run --json`
- `git diff --check`

## Executor revalidation — 2026-06-14
- Confirmed this branch is current with upstream `main` (`origin/main...HEAD` = `0 1`).
- Re-ran package metadata assertion for `name`, `repository`, `homepage`, `bugs.url`, and `license`.
- Re-ran `pnpm exec prettier package.json --check`.
- Re-ran `npm pack --dry-run --json` (package dry-run succeeds; metadata-only package contents unchanged except manifest fields).
- Re-ran `git diff --check origin/main...HEAD`.
