### PR TITLE
Update README with recommendation for Workers Tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An OpenTelemetry compatible library for instrumenting and exporting traces from Cloudflare Workers.
 
+> [!IMPORTANT]
+> You should almost always instead use [Workers Tracing](https://developers.cloudflare.com/workers/observability/traces/) — the OTEL tracing that is built into the Cloudflare Workers runtime, which automatically instruments your code and [provides APIs to write custom spans](https://developers.cloudflare.com/workers/observability/traces/custom-spans/), and [export traces to external destinations](https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/), with or without persisting data to Cloudflare.
+```
+
 ## Getting started
 
 ```bash


### PR DESCRIPTION
Adds a note at the top of the readme that recommends using Workers Tracing.

Happy to discuss how to frame and place this — but adding this coming out of a conversation where someone ended up using this package not aware that there are built-in runtime APIs that let you add custom spans, including https://github.com/cloudflare/cloudflare-docs/pull/31853 which is landing soon. And not aware that there is an option to export OTEL while not persisting traces to Cloudflare.

This library, `otel-cf-workers` is awesome and has helped so many people! Intent here not to throw shade but to try to help steer people towards the best outcome now that this is something we provide built-in APIs for.
